### PR TITLE
Disabling CA1812 - prohibits use of top level programs

### DIFF
--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -58,6 +58,7 @@
         <Rule Id="CA1725" Action="None" />
         <Rule Id="CA1805" Action="None" />
         <Rule Id="CA1810" Action="None" />
+        <Rule Id="CA1812" Action="None" />
         <Rule Id="CA1816" Action="None" />
         <Rule Id="CA1822" Action="None" />
         <Rule Id="CA1829" Action="Error" />


### PR DESCRIPTION
### Fixed

- Disable static code analysis rule CA1812 - it prohibited the use of top level programs. This started occurring after upgrading to .NET Core 6 RC2 - we might be able to revert this change later.
