### PR TITLE
Disable RCS1217 and SA1308

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -21,6 +21,7 @@
         <Rule Id="SA1304" Action="None" />
         <Rule Id="SA1306" Action="None" />
         <Rule Id="SA1307" Action="None" />
+        <Rule Id="SA1308" Action="None" />
         <Rule Id="SA1309" Action="None" />
         <Rule Id="SA1310" Action="None" />
         <Rule Id="SA1311" Action="None" />
@@ -105,6 +106,7 @@
         <Rule Id="RCS1194" Action="None" />
         <Rule Id="RCS1202" Action="None" />
         <Rule Id="RCS1213" Action="None" />
+        <Rule Id="RCS1217" Action="None" />
         <Rule Id="RCS1225" Action="None" />
     </Rules>
 </RuleSet>

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -11,6 +11,7 @@
         <Rule Id="SA1200" Action="Error" />
         <Rule Id="SA1210" Action="Error" />
         <Rule Id="SA1300" Action="None" />
+        <Rule Id="SA1308" Action="None" />
         <Rule Id="SA1309" Action="None" />
         <Rule Id="SA1400" Action="None" />
         <Rule Id="SA1401" Action="None" />
@@ -76,6 +77,7 @@
         <Rule Id="RCS1158" Action="None" />
         <Rule Id="RCS1182" Action="Error" />
         <Rule Id="RCS1194" Action="None" />
+        <Rule Id="RCS1217" Action="None" />
         <Rule Id="RCS1225" Action="None" />
     </Rules>
 </RuleSet>


### PR DESCRIPTION
### Fixed

- Allowing string interpolation over concatenation (RCS1217)
- Allowing `ToLowerInvariant()` on strings (SA1308)
