### PR TITLE
Allowing for unused parameters

### DIFF
--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -75,6 +75,7 @@
         <Rule Id="RCS1057" Action="Error" />
         <Rule Id="RCS1079" Action="None" />
         <Rule Id="RCS1158" Action="None" />
+        <Rule Id="RCS1163" Action="None" />
         <Rule Id="RCS1182" Action="Error" />
         <Rule Id="RCS1194" Action="None" />
         <Rule Id="RCS1217" Action="None" />


### PR DESCRIPTION
### Fixed

- Disabling RCS1163 to allow for unused parameters on methods.