### PR TITLE
Improve error messages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "finalizers"
+    ]
+}

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Constructors/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Constructors/Analyzer.cs
@@ -10,7 +10,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
         public override DiagnosticDescriptor Rule => new(
             id: "AS0013",
             title: "ConstructorsMustAppearInTheCorrectOrder",
-            messageFormat: "Constructors must after fields/properties/delegates/events, and before finalizers/indexers/methods",
+            messageFormat: "Constructors must come after fields/properties/delegates/events, and before finalizers/indexers/methods",
             category: "Exceptions",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Delegates/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Delegates/Analyzer.cs
@@ -10,7 +10,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
         public override DiagnosticDescriptor Rule => new(
             id: "AS0011",
             title: "DelegateElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Delegates must after fields/properties and before events/constructors/finalizers/indexers/methods",
+            messageFormat: "Delegates must come after fields/properties and before events/constructors/finalizers/indexers/methods",
             category: "Exceptions",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Events/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Events/Analyzer.cs
@@ -10,7 +10,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
         public override DiagnosticDescriptor Rule => new(
             id: "AS0012",
             title: "EventElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Events must after fields/properties/delegates and before constructors/finalizers/indexers/methods",
+            messageFormat: "Events must come after fields/properties/delegates and before constructors/finalizers/indexers/methods",
             category: "Exceptions",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Fields/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Fields/Analyzer.cs
@@ -10,7 +10,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
         public override DiagnosticDescriptor Rule => new(
             id: "AS0009",
             title: "FieldsMustAppearInTheCorrectOrder",
-            messageFormat: "Fields must before delegates/events/constructors/finalizers/indexers/methods",
+            messageFormat: "Fields must come before delegates/events/constructors/finalizers/indexers/methods",
             category: "Exceptions",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Finalizers/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Finalizers/Analyzer.cs
@@ -10,7 +10,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
         public override DiagnosticDescriptor Rule => new(
             id: "AS0014",
             title: "FinalizerElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Finalizers must after fields/properties/delegates/events/constructors and before indexers/methods",
+            messageFormat: "Finalizers must come after fields/properties/delegates/events/constructors and before indexers/methods",
             category: "Exceptions",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Indexers/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Indexers/Analyzer.cs
@@ -10,7 +10,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
         public override DiagnosticDescriptor Rule => new(
             id: "AS0015",
             title: "IndexerElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Indexers must after fields/properties/delegates/events/constructors/finalizers and before methods",
+            messageFormat: "Indexers must come after fields/properties/delegates/events/constructors/finalizers and before methods",
             category: "Exceptions",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Methods/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Methods/Analyzer.cs
@@ -10,7 +10,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
         public override DiagnosticDescriptor Rule => new(
             id: "AS0016",
             title: "MethodElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Methods must after fields/properties/delegates/events/constructors/indexers",
+            messageFormat: "Methods must come after fields/properties/delegates/events/constructors/indexers",
             category: "Exceptions",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/Analyzer.cs
@@ -10,7 +10,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
         public override DiagnosticDescriptor Rule => new(
             id: "AS0010",
             title: "PropertiesMustAppearInTheCorrectOrder",
-            messageFormat: "Properties must before delegates, events, constructors, finalizers, indexers and methods",
+            messageFormat: "Properties must come before delegates, events, constructors, finalizers, indexers and methods",
             category: "Exceptions",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,


### PR DESCRIPTION
### Fixed

- Improve error messages for ordering rules to include the word **come** in the context of *before* and *after*.
