### PR TITLE
Allowing-different-ordering-on-private-properties

### DIFF
--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/Analyzer.cs
@@ -21,5 +21,8 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
 
         /// <inheritdoc/>
         protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.PropertyDeclaration;
+
+        /// <inheritdoc/>
+        protected override IEnumerable<SyntaxKind> Modifiers => new[] { SyntaxKind.PublicKeyword };
     }
 }

--- a/Source/CodeAnalysis/Extensions.cs
+++ b/Source/CodeAnalysis/Extensions.cs
@@ -28,7 +28,7 @@ namespace Aksio.CodeAnalysis
         {
             var classSymbol = model.GetDeclaredSymbol(classDeclaration);
             var baseType = classSymbol.BaseType;
-            if( baseType == default )
+            if (baseType == default)
             {
                 return false;
             }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/UnitTests.cs
@@ -33,12 +33,15 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
                         "";
                     }
                     void ØkTeller() => ++Teller;
+
+                    // Private properties should be ignored
+                    int TellerPlus1 => Teller+1;
                 }
             ";
 
             VerifyCSharpDiagnostic(content);
         }
-        
+
         [Fact]
         public void PropertiesAfterDelegates()
         {
@@ -140,6 +143,7 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
 
             VerifyCSharpDiagnostic(content, GetExpectedFailures());
         }
+
 
         [Fact]
         public void AnalyzerDoesNotCrashOnEmptyClass()


### PR DESCRIPTION
### Fixed

- Property ordering ignores anything but public properties now. Reason for this is that it ends up conflicting with other rules wanting publics before privates and causing private properties to sit inbetween public properties and public constructors and not in their more natural location.
