### PR TITLE
Rulefixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ indent_size = 2
 
 [*.{cs,vb}]
 dotnet_analyzer_diagnostic.severity = warning
+file_header_template = Copyright (c) Aksio Insurtech. All rights reserved.\nLicensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #### .NET Conventions ####
 dotnet_sort_system_directives_first = true:error
@@ -37,7 +38,7 @@ dotnet_naming_symbols.const_fields.applicable_accessibilities                   
 dotnet_naming_symbols.const_fields.required_modifiers                           = const
 
 dotnet_naming_style.const_fields.capitalization                                 = pascal_case
-dotnet_naming_style.const_fields.required_prefix                                = 
+dotnet_naming_style.const_fields.required_prefix                                =
 
 # public static fields are pascal case
 dotnet_naming_rule.static_readonly_fields.symbols                               = static_readonly_fields
@@ -49,7 +50,7 @@ dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities         
 dotnet_naming_symbols.static_readonly_fields.required_modifiers                 = static
 
 dotnet_naming_style.static_readonly_fields.capitalization                       = pascal_case
-dotnet_naming_style.static_readonly_fields.required_prefix                      = 
+dotnet_naming_style.static_readonly_fields.required_prefix                      =
 
 # private fields should be camel case and start with _
 dotnet_naming_rule.private_Fields.symbols                                       = private_fields
@@ -58,10 +59,12 @@ dotnet_naming_rule.private_Fields.severity                                      
 
 dotnet_naming_symbols.private_fields.applicable_kinds                           = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities                 = private
-dotnet_naming_symbols.private_fields.required_modifiers                         = 
+dotnet_naming_symbols.private_fields.required_modifiers                         =
 
 dotnet_naming_style.private_fields.capitalization                               = camel_case
 dotnet_naming_style.private_fields.required_prefix                              = _
+
+
 
 # upper camelcase for public properties
 dotnet_naming_rule.public_members_must_be_capitalized.style = first_word_upper_case_style
@@ -71,7 +74,44 @@ dotnet_naming_symbols.public_symbols.applicable_kinds = property,method,field,ev
 dotnet_naming_symbols.public_symbols.applicable_accessibilities = public
 dotnet_naming_symbols.public_symbols.required_modifiers = readonly
 
+## Specific rule suppression
+# CA1822: Mark members as static
+dotnet_diagnostic.CA1822.severity = none
+# CA2016: Forward the CancellationToken parameter to methods that take one
+dotnet_diagnostic.CA2016.severity = none
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = none
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = none
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = none
+#CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = none
+# Add missing cases to switch expression (IDE0072 and IDE0010)
+# a bug in roslyn: https://github.com/dotnet/roslyn/issues/48876
+dotnet_diagnostic.IDE0072.severity = none
+dotnet_diagnostic.IDE0010.severity = none
+# IDE0130: Namespace does not match folder structure
+dotnet_diagnostic.IDE0130.severity = none
+# CA1834: Use StringBuilder.Append(char) for single character strings
+dotnet_diagnostic.CA1834.severity = none
+# CA1805: Do not initialize unnecessarily.
+dotnet_diagnostic.CA1805.severity = none
+# Use pattern matching (not operator) (IDE0083)
+dotnet_diagnostic.IDE0083.severity = none
+# CA1309: Use ordinal StringComparison
+dotnet_diagnostic.CA1309.severity = none
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity = none
+# RCS1018: Add accessibility modifiers
+dotnet_diagnostic.RCS1018.severity = none
+# RCS1194: Implement exception constructors
+dotnet_diagnostic.RCS1194.severity = none
+
 #### C# Coding Conventions ####
+
+# File scoped namespace
+csharp_style_namespace_declarations = file_scoped:warning
 
 # var preferences
 csharp_style_var_elsewhere = true:error
@@ -101,10 +141,14 @@ csharp_style_unused_value_expression_statement_preference = false:none
 
 # not ready for changing everything to pattern matching
 csharp_style_prefer_pattern_matching = false:none
+
 csharp_using_directive_placement = outside_namespace:error
+
+
 csharp_style_prefer_range_operator = false:none
 
 # CSharp formatting rules:
 # dont want these bombing the build logs, will still show up in the IDE
+dotnet_diagnostic.IDE0055.severity = none
 # prefere brace indentation when creating objects etc
 csharp_indent_braces = false

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Constructors/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Constructors/Analyzer.cs
@@ -1,25 +1,27 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
-{
-    /// <summary>
-    /// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires constructor in a specific order.
-    /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
-    {
-        /// <inheritdoc/>
-        public override DiagnosticDescriptor Rule => new(
-            id: "AS0013",
-            title: "ConstructorsMustAppearInTheCorrectOrder",
-            messageFormat: "Constructors must come after fields/properties/delegates/events, and before finalizers/indexers/methods",
-            category: "Exceptions",
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            description: null,
-            helpLinkUri: string.Empty,
-            customTags: Array.Empty<string>()
-        );
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        /// <inheritdoc/>
-        protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.ConstructorDeclaration;
-    }
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors;
+
+/// <summary>
+/// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires constructor in a specific order.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
+{
+    /// <inheritdoc/>
+    public override DiagnosticDescriptor Rule => new(
+        id: "AS0013",
+        title: "ConstructorsMustAppearInTheCorrectOrder",
+        messageFormat: "Constructors must come after fields/properties/delegates/events, and before finalizers/indexers/methods",
+        category: "Exceptions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: null,
+        helpLinkUri: string.Empty,
+        customTags: Array.Empty<string>()
+    );
+
+    /// <inheritdoc/>
+    protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.ConstructorDeclaration;
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Delegates/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Delegates/Analyzer.cs
@@ -1,27 +1,29 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
-{
-    /// <summary>
-    /// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires delegates in a specific order.
-    /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
-    {
-        /// <inheritdoc/>
-        public override DiagnosticDescriptor Rule => new(
-            id: "AS0011",
-            title: "DelegateElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Delegates must come after fields/properties and before events/constructors/finalizers/indexers/methods",
-            category: "Exceptions",
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            description: null,
-            helpLinkUri: string.Empty,
-            customTags: Array.Empty<string>()
-        );
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        /// <summary>
-        /// The element kind we are checking the ordering for.
-        /// </summary>
-        protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.DelegateDeclaration;
-    }
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates;
+
+/// <summary>
+/// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires delegates in a specific order.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
+{
+    /// <inheritdoc/>
+    public override DiagnosticDescriptor Rule => new(
+        id: "AS0011",
+        title: "DelegateElementsMustAppearInTheCorrectOrder",
+        messageFormat: "Delegates must come after fields/properties and before events/constructors/finalizers/indexers/methods",
+        category: "Exceptions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: null,
+        helpLinkUri: string.Empty,
+        customTags: Array.Empty<string>()
+    );
+
+    /// <summary>
+    /// The element kind we are checking the ordering for.
+    /// </summary>
+    protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.DelegateDeclaration;
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/ElementOrderList.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/ElementOrderList.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder;
 
 /// <summary>

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/ElementsMustAppearInTheCorrectOrderAnalyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/ElementsMustAppearInTheCorrectOrderAnalyzer.cs
@@ -1,119 +1,121 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder;
+
+/// <summary>
+/// Represents an abstract base <see cref="DiagnosticAnalyzer"/> for requiring a specific order of an element.
+/// </summary>
+public abstract class ElementsMustAppearInTheCorrectOrderAnalyzer : DiagnosticAnalyzer
 {
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
     /// <summary>
-    /// Represents an abstract base <see cref="DiagnosticAnalyzer"/> for requiring a specific order of an element.
+    /// Gets the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
     /// </summary>
-    public abstract class ElementsMustAppearInTheCorrectOrderAnalyzer : DiagnosticAnalyzer
+    public abstract DiagnosticDescriptor Rule { get; }
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
     {
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(ValidateRule, ImmutableArray.Create(SyntaxKind.ClassDeclaration));
+    }
 
-        /// <summary>
-        /// Gets the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
-        /// </summary>
-        public abstract DiagnosticDescriptor Rule { get; }
+    /// <summary>
+    /// Gets the element kind we are checking the ordering for.
+    /// </summary>
+    protected abstract SyntaxKind KindToCheckFor { get; }
 
-        /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+    void ValidateRule(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not ClassDeclarationSyntax classDeclaration)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-            context.RegisterSyntaxNodeAction(ValidateRule, ImmutableArray.Create(SyntaxKind.ClassDeclaration));
+            return;
         }
 
-        /// <summary>
-        /// Gets the element kind we are checking the ordering for.
-        /// </summary>
-        protected abstract SyntaxKind KindToCheckFor { get; }
+        var elementToCheckFor = KindToElementOrder(KindToCheckFor);
 
-        void ValidateRule(SyntaxNodeAnalysisContext context)
+        var currentKindList = classDeclaration.Members
+            .OnlyWithSupportedModifiersFor(Visibility)
+            .Select((m, pos) => (Member: m, Position: pos))
+            .Where(_ => _.Member.Kind() == KindToCheckFor)
+            .ToList();
+
+        // Each instance of the element before the end of the types that should be before it generates an error
+        var lastBeforeElementPosition = LastBeforeElementPosition(classDeclaration, elementToCheckFor);
+        foreach (var (member, _) in currentKindList.Where(_ => _.Position < lastBeforeElementPosition))
         {
-            if (context.Node is not ClassDeclarationSyntax classDeclaration)
-            {
-                return;
-            }
-
-            var elementToCheckFor = KindToElementOrder(KindToCheckFor);
-
-            var currentKindList = classDeclaration.Members
-                .OnlyWithSupportedModifiersFor(Visibility)
-                .Select((m, pos) => (Member: m, Position: pos))
-                .Where(_ => _.Member.Kind() == KindToCheckFor)
-                .ToList();
-
-            // Each instance of the element before the end of the types that should be before it generates an error
-            var lastBeforeElementPosition = LastBeforeElementPosition(classDeclaration, elementToCheckFor);
-            foreach (var (member, _) in currentKindList.Where(_ => _.Position < lastBeforeElementPosition))
-            {
-                context.ReportDiagnostic(Diagnostic.Create(Rule, member.GetLocation()));
-            }
-
-            // Each instance of the element after the start of the types that should be after it generates an error
-            var firstAfterElementPosition = FirstAfterElementPosition(classDeclaration, elementToCheckFor);
-            foreach (var (member, _) in currentKindList.Where(_ => _.Position > firstAfterElementPosition))
-            {
-                context.ReportDiagnostic(Diagnostic.Create(Rule, member.GetLocation()));
-            }
+            context.ReportDiagnostic(Diagnostic.Create(Rule, member.GetLocation()));
         }
 
-        int LastBeforeElementPosition(ClassDeclarationSyntax classDeclaration, ElementOrderList elementOrderToCheckFor)
+        // Each instance of the element after the start of the types that should be after it generates an error
+        var firstAfterElementPosition = FirstAfterElementPosition(classDeclaration, elementToCheckFor);
+        foreach (var (member, _) in currentKindList.Where(_ => _.Position > firstAfterElementPosition))
         {
-            var otherElementTypes = classDeclaration.Members
-                .OnlyWithSupportedModifiersFor(Visibility)
-                .Select((m, pos) => (ElementOrder: KindToElementOrder(m.Kind()), Position: pos))
-                .Where(_ => _.ElementOrder != elementOrderToCheckFor)
-                .ToList();
+            context.ReportDiagnostic(Diagnostic.Create(Rule, member.GetLocation()));
+        }
+    }
 
-            var elementsThatShouldBeBefore = otherElementTypes.Where(_ => _.ElementOrder < elementOrderToCheckFor).ToList();
-            if (elementsThatShouldBeBefore.Count == 0)
-            {
-                return 0;
-            }
+    int LastBeforeElementPosition(ClassDeclarationSyntax classDeclaration, ElementOrderList elementOrderToCheckFor)
+    {
+        var otherElementTypes = classDeclaration.Members
+            .OnlyWithSupportedModifiersFor(Visibility)
+            .Select((m, pos) => (ElementOrder: KindToElementOrder(m.Kind()), Position: pos))
+            .Where(_ => _.ElementOrder != elementOrderToCheckFor)
+            .ToList();
 
-            return elementsThatShouldBeBefore.Max(_ => _.Position);
+        var elementsThatShouldBeBefore = otherElementTypes.Where(_ => _.ElementOrder < elementOrderToCheckFor).ToList();
+        if (elementsThatShouldBeBefore.Count == 0)
+        {
+            return 0;
         }
 
-        int FirstAfterElementPosition(ClassDeclarationSyntax classDeclaration, ElementOrderList elementOrderToCheckFor)
+        return elementsThatShouldBeBefore.Max(_ => _.Position);
+    }
+
+    int FirstAfterElementPosition(ClassDeclarationSyntax classDeclaration, ElementOrderList elementOrderToCheckFor)
+    {
+        var kindAndPosition = classDeclaration.Members
+            .OnlyWithSupportedModifiersFor(Visibility)
+            .Select((m, pos) => (ElementOrder: KindToElementOrder(m.Kind()), Position: pos))
+            .Where(_ => _.ElementOrder != elementOrderToCheckFor)
+            .ToList();
+
+        var elementsThatShouldBeAfter = kindAndPosition.Where(_ => _.ElementOrder > elementOrderToCheckFor).ToList();
+        if (elementsThatShouldBeAfter.Count == 0)
         {
-            var kindAndPosition = classDeclaration.Members
-                .OnlyWithSupportedModifiersFor(Visibility)
-                .Select((m, pos) => (ElementOrder: KindToElementOrder(m.Kind()), Position: pos))
-                .Where(_ => _.ElementOrder != elementOrderToCheckFor)
-                .ToList();
-
-            var elementsThatShouldBeAfter = kindAndPosition.Where(_ => _.ElementOrder > elementOrderToCheckFor).ToList();
-            if (elementsThatShouldBeAfter.Count == 0)
-            {
-                return classDeclaration.Members.Count;
-            }
-
-            return elementsThatShouldBeAfter.Min(_ => _.Position);
+            return classDeclaration.Members.Count;
         }
 
-        ElementOrderList KindToElementOrder(SyntaxKind syntaxKind)
-        {
-            return syntaxKind switch
-            {
-                SyntaxKind.FieldDeclaration => ElementOrderList.FieldsAndProperties,
-                SyntaxKind.PropertyDeclaration => ElementOrderList.FieldsAndProperties,
-                SyntaxKind.DelegateDeclaration => ElementOrderList.Delegates,
-                SyntaxKind.EventFieldDeclaration => ElementOrderList.Events,
-                SyntaxKind.EventDeclaration => ElementOrderList.Events,
-                SyntaxKind.ConstructorDeclaration => ElementOrderList.Constructors,
-                SyntaxKind.DestructorDeclaration => ElementOrderList.Destructors,
-                SyntaxKind.IndexerDeclaration => ElementOrderList.Indexers,
-                SyntaxKind.MethodDeclaration => ElementOrderList.Methods,
-                _ => ElementOrderList.Undefined
-            };
-        }
+        return elementsThatShouldBeAfter.Min(_ => _.Position);
+    }
 
-        IEnumerable<SyntaxKind> Visibility(MemberDeclarationSyntax member)
+    ElementOrderList KindToElementOrder(SyntaxKind syntaxKind)
+    {
+        return syntaxKind switch
         {
-            return member.Kind() switch
-            {
-                SyntaxKind.PropertyDeclaration => new[] { SyntaxKind.PublicKeyword },
-                _ => Array.Empty<SyntaxKind>()
-            };
-        }
+            SyntaxKind.FieldDeclaration => ElementOrderList.FieldsAndProperties,
+            SyntaxKind.PropertyDeclaration => ElementOrderList.FieldsAndProperties,
+            SyntaxKind.DelegateDeclaration => ElementOrderList.Delegates,
+            SyntaxKind.EventFieldDeclaration => ElementOrderList.Events,
+            SyntaxKind.EventDeclaration => ElementOrderList.Events,
+            SyntaxKind.ConstructorDeclaration => ElementOrderList.Constructors,
+            SyntaxKind.DestructorDeclaration => ElementOrderList.Destructors,
+            SyntaxKind.IndexerDeclaration => ElementOrderList.Indexers,
+            SyntaxKind.MethodDeclaration => ElementOrderList.Methods,
+            _ => ElementOrderList.Undefined
+        };
+    }
+
+    IEnumerable<SyntaxKind> Visibility(MemberDeclarationSyntax member)
+    {
+        return member.Kind() switch
+        {
+            SyntaxKind.PropertyDeclaration => new[] { SyntaxKind.PublicKeyword },
+            _ => Array.Empty<SyntaxKind>()
+        };
     }
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Events/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Events/Analyzer.cs
@@ -1,27 +1,29 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
-{
-    /// <summary>
-    /// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires events in a specific order.
-    /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
-    {
-        /// <inheritdoc/>
-        public override DiagnosticDescriptor Rule => new(
-            id: "AS0012",
-            title: "EventElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Events must come after fields/properties/delegates and before constructors/finalizers/indexers/methods",
-            category: "Exceptions",
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            description: null,
-            helpLinkUri: string.Empty,
-            customTags: Array.Empty<string>()
-        );
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        /// <summary>
-        /// The element kind we are checking the ordering for.
-        /// </summary>
-        protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.EventFieldDeclaration;
-    }
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events;
+
+/// <summary>
+/// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires events in a specific order.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
+{
+    /// <inheritdoc/>
+    public override DiagnosticDescriptor Rule => new(
+        id: "AS0012",
+        title: "EventElementsMustAppearInTheCorrectOrder",
+        messageFormat: "Events must come after fields/properties/delegates and before constructors/finalizers/indexers/methods",
+        category: "Exceptions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: null,
+        helpLinkUri: string.Empty,
+        customTags: Array.Empty<string>()
+    );
+
+    /// <summary>
+    /// The element kind we are checking the ordering for.
+    /// </summary>
+    protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.EventFieldDeclaration;
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Fields/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Fields/Analyzer.cs
@@ -1,27 +1,29 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
-{
-    /// <summary>
-    /// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires fields in a specific order.
-    /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
-    {
-        /// <inheritdoc/>
-        public override DiagnosticDescriptor Rule => new(
-            id: "AS0009",
-            title: "FieldsMustAppearInTheCorrectOrder",
-            messageFormat: "Fields must come before delegates/events/constructors/finalizers/indexers/methods",
-            category: "Exceptions",
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            description: null,
-            helpLinkUri: string.Empty,
-            customTags: Array.Empty<string>()
-        );
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        /// <summary>
-        /// Gets the element kind we are checking the ordering for.
-        /// </summary>
-        protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.FieldDeclaration;
-    }
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields;
+
+/// <summary>
+/// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires fields in a specific order.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
+{
+    /// <inheritdoc/>
+    public override DiagnosticDescriptor Rule => new(
+        id: "AS0009",
+        title: "FieldsMustAppearInTheCorrectOrder",
+        messageFormat: "Fields must come before delegates/events/constructors/finalizers/indexers/methods",
+        category: "Exceptions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: null,
+        helpLinkUri: string.Empty,
+        customTags: Array.Empty<string>()
+    );
+
+    /// <summary>
+    /// Gets the element kind we are checking the ordering for.
+    /// </summary>
+    protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.FieldDeclaration;
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Finalizers/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Finalizers/Analyzer.cs
@@ -1,25 +1,27 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
-{
-    /// <summary>
-    /// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires finalizers in a specific order.
-    /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
-    {
-        /// <inheritdoc/>
-        public override DiagnosticDescriptor Rule => new(
-            id: "AS0014",
-            title: "FinalizerElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Finalizers must come after fields/properties/delegates/events/constructors and before indexers/methods",
-            category: "Exceptions",
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            description: null,
-            helpLinkUri: string.Empty,
-            customTags: Array.Empty<string>()
-        );
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        /// <inheritdoc/>
-        protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.DestructorDeclaration;
-    }
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers;
+
+/// <summary>
+/// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires finalizers in a specific order.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
+{
+    /// <inheritdoc/>
+    public override DiagnosticDescriptor Rule => new(
+        id: "AS0014",
+        title: "FinalizerElementsMustAppearInTheCorrectOrder",
+        messageFormat: "Finalizers must come after fields/properties/delegates/events/constructors and before indexers/methods",
+        category: "Exceptions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: null,
+        helpLinkUri: string.Empty,
+        customTags: Array.Empty<string>()
+    );
+
+    /// <inheritdoc/>
+    protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.DestructorDeclaration;
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Indexers/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Indexers/Analyzer.cs
@@ -1,25 +1,27 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
-{
-    /// <summary>
-    /// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires indexers in a specific order.
-    /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
-    {
-        /// <inheritdoc/>
-        public override DiagnosticDescriptor Rule => new(
-            id: "AS0015",
-            title: "IndexerElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Indexers must come after fields/properties/delegates/events/constructors/finalizers and before methods",
-            category: "Exceptions",
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            description: null,
-            helpLinkUri: string.Empty,
-            customTags: Array.Empty<string>()
-        );
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        /// <inheritdoc/>
-        protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.IndexerDeclaration;
-    }
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers;
+
+/// <summary>
+/// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires indexers in a specific order.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
+{
+    /// <inheritdoc/>
+    public override DiagnosticDescriptor Rule => new(
+        id: "AS0015",
+        title: "IndexerElementsMustAppearInTheCorrectOrder",
+        messageFormat: "Indexers must come after fields/properties/delegates/events/constructors/finalizers and before methods",
+        category: "Exceptions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: null,
+        helpLinkUri: string.Empty,
+        customTags: Array.Empty<string>()
+    );
+
+    /// <inheritdoc/>
+    protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.IndexerDeclaration;
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/MemberFiltersExtensions.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/MemberFiltersExtensions.cs
@@ -1,34 +1,36 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder;
+
+/// <summary>
+/// Extension methods for working with members and filtering.
+/// </summary>
+public static class MemberFiltersExtensions
 {
     /// <summary>
-    /// Extension methods for working with members and filtering.
+    /// Filter members for any of the supported modifiers.
     /// </summary>
-    public static class MemberFiltersExtensions
+    /// <param name="members">Enumerable to filter.</param>
+    /// <param name="getModifiers">Callback for getting modifiers.</param>
+    /// <returns>Filtered members.</returns>
+    public static IEnumerable<MemberDeclarationSyntax> OnlyWithSupportedModifiersFor(this SyntaxList<MemberDeclarationSyntax> members, Func<MemberDeclarationSyntax, IEnumerable<SyntaxKind>> getModifiers)
     {
-        /// <summary>
-        /// Filter members for any of the supported modifiers.
-        /// </summary>
-        /// <param name="members">Enumerable to filter.</param>
-        /// <param name="getModifiers">Callback for getting modifiers.</param>
-        /// <returns>Filtered members.</returns>
-        public static IEnumerable<MemberDeclarationSyntax> OnlyWithSupportedModifiersFor(this SyntaxList<MemberDeclarationSyntax> members, Func<MemberDeclarationSyntax, IEnumerable<SyntaxKind>> getModifiers)
+        return members.Where(_ =>
         {
-            return members.Where(_ =>
+            var modifiers = getModifiers(_);
+            if (!modifiers.Any())
             {
-                var modifiers = getModifiers(_);
-                if (!modifiers.Any())
-                {
-                    return true;
-                }
+                return true;
+            }
 
-                var contains = false;
-                foreach (var modifier in modifiers)
-                {
-                    contains |= _.Modifiers.Any(modifier);
-                }
+            var contains = false;
+            foreach (var modifier in modifiers)
+            {
+                contains |= _.Modifiers.Any(modifier);
+            }
 
-                return contains;
-            });
-        }
+            return contains;
+        });
     }
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Methods/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Methods/Analyzer.cs
@@ -1,27 +1,29 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
-{
-    /// <summary>
-    /// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires methods in a specific order.
-    /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
-    {
-        /// <inheritdoc/>
-        public override DiagnosticDescriptor Rule => new(
-            id: "AS0016",
-            title: "MethodElementsMustAppearInTheCorrectOrder",
-            messageFormat: "Methods must come after fields/properties/delegates/events/constructors/indexers",
-            category: "Exceptions",
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            description: null,
-            helpLinkUri: string.Empty,
-            customTags: Array.Empty<string>()
-        );
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        /// <summary>
-        /// The element kind we are checking the ordering for.
-        /// </summary>
-        protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.MethodDeclaration;
-    }
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods;
+
+/// <summary>
+/// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires methods in a specific order.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
+{
+    /// <inheritdoc/>
+    public override DiagnosticDescriptor Rule => new(
+        id: "AS0016",
+        title: "MethodElementsMustAppearInTheCorrectOrder",
+        messageFormat: "Methods must come after fields/properties/delegates/events/constructors/indexers",
+        category: "Exceptions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: null,
+        helpLinkUri: string.Empty,
+        customTags: Array.Empty<string>()
+    );
+
+    /// <summary>
+    /// The element kind we are checking the ordering for.
+    /// </summary>
+    protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.MethodDeclaration;
 }

--- a/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/Analyzer.cs
+++ b/Source/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/Analyzer.cs
@@ -1,25 +1,27 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
-{
-    /// <summary>
-    /// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires properties in a specific order.
-    /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
-    {
-        /// <inheritdoc/>
-        public override DiagnosticDescriptor Rule => new(
-            id: "AS0010",
-            title: "PropertiesMustAppearInTheCorrectOrder",
-            messageFormat: "Properties must come before delegates, events, constructors, finalizers, indexers and methods",
-            category: "Exceptions",
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true,
-            description: null,
-            helpLinkUri: string.Empty,
-            customTags: Array.Empty<string>()
-        );
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        /// <inheritdoc/>
-        protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.PropertyDeclaration;
-    }
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties;
+
+/// <summary>
+/// Represents a <see cref="ElementsMustAppearInTheCorrectOrderAnalyzer"/> that requires properties in a specific order.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : ElementsMustAppearInTheCorrectOrderAnalyzer
+{
+    /// <inheritdoc/>
+    public override DiagnosticDescriptor Rule => new(
+        id: "AS0010",
+        title: "PropertiesMustAppearInTheCorrectOrder",
+        messageFormat: "Properties must come before delegates, events, constructors, finalizers, indexers and methods",
+        category: "Exceptions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: null,
+        helpLinkUri: string.Empty,
+        customTags: Array.Empty<string>()
+    );
+
+    /// <inheritdoc/>
+    protected override SyntaxKind KindToCheckFor { get; } = SyntaxKind.PropertyDeclaration;
 }

--- a/Source/CodeAnalysis/ExceptionConstructorParametersShouldNotContainMessage/Analyzer.cs
+++ b/Source/CodeAnalysis/ExceptionConstructorParametersShouldNotContainMessage/Analyzer.cs
@@ -1,61 +1,63 @@
-﻿namespace Aksio.CodeAnalysis.ExceptionConstructorParametersShouldNotContainMessage
+﻿// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionConstructorParametersShouldNotContainMessage;
+
+/// <summary>
+/// Represents a <see cref="DiagnosticAnalyzer"/> that requires exceptions to not use message as a parameter name - tends to indicate that it is a generic exception.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : DiagnosticAnalyzer
 {
     /// <summary>
-    /// Represents a <see cref="DiagnosticAnalyzer"/> that requires exceptions to not use message as a parameter name - tends to indicate that it is a generic exception.
+    /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : DiagnosticAnalyzer
+    public static readonly DiagnosticDescriptor Rule = new(
+         id: "AS0006",
+         title: "ExceptionConstructorParametersShouldNotContainMessage",
+         messageFormat: "An argument of an exception with the name 'message' in it indicates its a generic exception and output string ownership is wrong",
+         category: "Exceptions",
+         defaultSeverity: DiagnosticSeverity.Error,
+         isEnabledByDefault: true,
+         description: null,
+         helpLinkUri: string.Empty,
+         customTags: Array.Empty<string>());
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
     {
-        /// <summary>
-        /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
-        /// </summary>
-        public static readonly DiagnosticDescriptor Rule = new(
-             id: "AS0006",
-             title: "ExceptionConstructorParametersShouldNotContainMessage",
-             messageFormat: "An argument of an exception with the name 'message' in it indicates its a generic exception and output string ownership is wrong",
-             category: "Exceptions",
-             defaultSeverity: DiagnosticSeverity.Error,
-             isEnabledByDefault: true,
-             description: null,
-             helpLinkUri: string.Empty,
-             customTags: Array.Empty<string>());
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(
+            HandleClassDeclaration,
+            ImmutableArray.Create(
+                SyntaxKind.ClassDeclaration));
+    }
 
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    void HandleClassDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var classDeclaration = context.Node as ClassDeclarationSyntax;
+        if (classDeclaration?.BaseList == null || classDeclaration?.BaseList?.Types == null) return;
 
-        /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        if (classDeclaration.InheritsASystemException(context.SemanticModel))
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-            context.RegisterSyntaxNodeAction(
-                HandleClassDeclaration,
-                ImmutableArray.Create(
-                    SyntaxKind.ClassDeclaration));
-        }
+            var constructors = classDeclaration.Members
+                                                    .Where(_ => _.IsKind(SyntaxKind.ConstructorDeclaration))
+                                                    .Select(_ => _ as ConstructorDeclarationSyntax);
 
-        void HandleClassDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var classDeclaration = context.Node as ClassDeclarationSyntax;
-            if (classDeclaration?.BaseList == null || classDeclaration?.BaseList?.Types == null) return;
-
-            if (classDeclaration.InheritsASystemException(context.SemanticModel))
+            foreach (var constructor in constructors)
             {
-                var constructors = classDeclaration.Members
-                                                        .Where(_ => _.IsKind(SyntaxKind.ConstructorDeclaration))
-                                                        .Select(_ => _ as ConstructorDeclarationSyntax);
-
-                foreach (var constructor in constructors)
+                var wronglyNamedParameters = constructor.ParameterList.Parameters
+                                                .Where(_ =>
+                                                    _.Type.ToString().EndsWith("string", StringComparison.InvariantCultureIgnoreCase) &&
+                                                    _.Identifier.Text.IndexOf("message", StringComparison.InvariantCultureIgnoreCase) >= 0);
+                foreach (var parameter in wronglyNamedParameters)
                 {
-                    var wronglyNamedParameters = constructor.ParameterList.Parameters
-                                                    .Where(_ =>
-                                                        _.Type.ToString().EndsWith("string", StringComparison.InvariantCultureIgnoreCase) &&
-                                                        _.Identifier.Text.IndexOf("message", StringComparison.InvariantCultureIgnoreCase) >= 0);
-                    foreach (var parameter in wronglyNamedParameters)
-                    {
-                        var diagnostic = Diagnostic.Create(Rule, parameter.Identifier.GetLocation());
-                        context.ReportDiagnostic(diagnostic);
-                    }
+                    var diagnostic = Diagnostic.Create(Rule, parameter.Identifier.GetLocation());
+                    context.ReportDiagnostic(diagnostic);
                 }
             }
         }

--- a/Source/CodeAnalysis/ExceptionDescriptionShouldFollowStandard/Analyzer.cs
+++ b/Source/CodeAnalysis/ExceptionDescriptionShouldFollowStandard/Analyzer.cs
@@ -1,74 +1,76 @@
-﻿namespace Aksio.CodeAnalysis.ExceptionDescriptionShouldFollowStandard
+﻿// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionDescriptionShouldFollowStandard;
+
+/// <summary>
+/// Represents a <see cref="DiagnosticAnalyzer"/> that requires a specific phrase for Exception API documentation.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : DiagnosticAnalyzer
 {
     /// <summary>
-    /// Represents a <see cref="DiagnosticAnalyzer"/> that requires a specific phrase for Exception API documentation.
+    /// The expected phrase.
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : DiagnosticAnalyzer
+    public const string Phrase = "Exception that gets thrown when";
+
+    /// <summary>
+    /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
+    /// </summary>
+    public static readonly DiagnosticDescriptor Rule = new(
+         id: "AS0007",
+         title: "ExceptionDescriptionShouldFollowStandard",
+         messageFormat: $"Exception description for API documentation should start with '{Phrase}'",
+         category: "Naming",
+         defaultSeverity: DiagnosticSeverity.Error,
+         isEnabledByDefault: true,
+         description: null,
+         helpLinkUri: string.Empty,
+         customTags: Array.Empty<string>());
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
     {
-        /// <summary>
-        /// The expected phrase.
-        /// </summary>
-        public const string Phrase = "Exception that gets thrown when";
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(
+            HandleClassDeclaration,
+            ImmutableArray.Create(
+                SyntaxKind.ClassDeclaration));
+    }
 
-        /// <summary>
-        /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
-        /// </summary>
-        public static readonly DiagnosticDescriptor Rule = new (
-             id: "AS0007",
-             title: "ExceptionDescriptionShouldFollowStandard",
-             messageFormat: $"Exception description for API documentation should start with '{Phrase}'",
-             category: "Naming",
-             defaultSeverity: DiagnosticSeverity.Error,
-             isEnabledByDefault: true,
-             description: null,
-             helpLinkUri: string.Empty,
-             customTags: Array.Empty<string>());
+    void HandleClassDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var classDeclaration = context.Node as ClassDeclarationSyntax;
+        if (classDeclaration?.BaseList == null || classDeclaration?.BaseList?.Types == null) return;
 
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
-
-        /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        if (classDeclaration.InheritsASystemException(context.SemanticModel))
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-            context.RegisterSyntaxNodeAction(
-                HandleClassDeclaration,
-                ImmutableArray.Create(
-                    SyntaxKind.ClassDeclaration));
-        }
-
-        void HandleClassDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var classDeclaration = context.Node as ClassDeclarationSyntax;
-            if (classDeclaration?.BaseList == null || classDeclaration?.BaseList?.Types == null) return;
-
-            if (classDeclaration.InheritsASystemException(context.SemanticModel))
+            foreach (var trivia in classDeclaration.GetLeadingTrivia())
             {
-                foreach (var trivia in classDeclaration.GetLeadingTrivia())
+                if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) ||
+                    trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia))
                 {
-                    if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) ||
-                        trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia))
+                    var descendants = trivia.GetStructure().DescendantTokens();
+                    var summaryTokenAndIndex = descendants
+                                                .Select((token, index) => new { Token = token, Index = index })
+                                                .FirstOrDefault(_ => _.Token.IsKind(SyntaxKind.IdentifierToken) && _.Token.Text.Equals("summary", StringComparison.InvariantCulture));
+
+                    if (summaryTokenAndIndex == default) return;
+
+                    var xmlTextLiteralToken = descendants
+                                    .Skip(summaryTokenAndIndex.Index)
+                                    .FirstOrDefault(_ => _.IsKind(SyntaxKind.XmlTextLiteralToken));
+
+                    if (xmlTextLiteralToken == default) return;
+
+                    if (!xmlTextLiteralToken.Text.Trim().StartsWith(Phrase, StringComparison.InvariantCulture))
                     {
-                        var descendants = trivia.GetStructure().DescendantTokens();
-                        var summaryTokenAndIndex = descendants
-                                                    .Select((token, index) => new { Token = token, Index = index })
-                                                    .FirstOrDefault(_ => _.Token.IsKind(SyntaxKind.IdentifierToken) && _.Token.Text.Equals("summary", StringComparison.InvariantCulture));
-
-                        if (summaryTokenAndIndex == default) return;
-
-                        var xmlTextLiteralToken = descendants
-                                        .Skip(summaryTokenAndIndex.Index)
-                                        .FirstOrDefault(_ => _.IsKind(SyntaxKind.XmlTextLiteralToken));
-
-                        if (xmlTextLiteralToken == default) return;
-
-                        if (!xmlTextLiteralToken.Text.Trim().StartsWith(Phrase, StringComparison.InvariantCulture))
-                        {
-                            var diagnostic = Diagnostic.Create(Rule, xmlTextLiteralToken.GetLocation());
-                            context.ReportDiagnostic(diagnostic);
-                        }
+                        var diagnostic = Diagnostic.Create(Rule, xmlTextLiteralToken.GetLocation());
+                        context.ReportDiagnostic(diagnostic);
                     }
                 }
             }

--- a/Source/CodeAnalysis/ExceptionShouldBeSpecific/Analyzer.cs
+++ b/Source/CodeAnalysis/ExceptionShouldBeSpecific/Analyzer.cs
@@ -1,57 +1,59 @@
-﻿namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific
+﻿// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific;
+
+/// <summary>
+/// Represents a <see cref="DiagnosticAnalyzer"/> that requires one to now throw a generic system exception.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : DiagnosticAnalyzer
 {
     /// <summary>
-    /// Represents a <see cref="DiagnosticAnalyzer"/> that requires one to now throw a generic system exception.
+    /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : DiagnosticAnalyzer
+    public static readonly DiagnosticDescriptor Rule = new(
+         id: "AS0008",
+         title: "ExceptionShouldBeSpecific",
+         messageFormat: "Throwing a generic system exception is not a allowed - you should create a specific exception",
+         category: "Exceptions",
+         defaultSeverity: DiagnosticSeverity.Error,
+         isEnabledByDefault: true,
+         description: null,
+         helpLinkUri: string.Empty,
+         customTags: Array.Empty<string>());
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
     {
-        /// <summary>
-        /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
-        /// </summary>
-        public static readonly DiagnosticDescriptor Rule = new(
-             id: "AS0008",
-             title: "ExceptionShouldBeSpecific",
-             messageFormat: "Throwing a generic system exception is not a allowed - you should create a specific exception",
-             category: "Exceptions",
-             defaultSeverity: DiagnosticSeverity.Error,
-             isEnabledByDefault: true,
-             description: null,
-             helpLinkUri: string.Empty,
-             customTags: Array.Empty<string>());
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        context.RegisterOperationAction(HandleThrow, ImmutableArray.Create(
+            OperationKind.Throw));
+    }
 
-        /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+    void HandleThrow(OperationAnalysisContext context)
+    {
+        if (context.Operation is IThrowOperation throwOperation)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-            context.RegisterOperationAction(HandleThrow, ImmutableArray.Create(
-                OperationKind.Throw));
-        }
-
-        void HandleThrow(OperationAnalysisContext context)
-        {
-            if (context.Operation is IThrowOperation throwOperation)
+            var exceptionOperation = throwOperation.Exception;
+            if (exceptionOperation is IConversionOperation conversionOperation)
             {
-                var exceptionOperation = throwOperation.Exception;
-                if (exceptionOperation is IConversionOperation conversionOperation)
-                {
-                    exceptionOperation = conversionOperation.Operand;
-                }
+                exceptionOperation = conversionOperation.Operand;
+            }
 
-                if (exceptionOperation is IObjectCreationOperation exception &&
-                    exception.Constructor.ContainingNamespace.Name.StartsWith("System", StringComparison.InvariantCulture))
+            if (exceptionOperation is IObjectCreationOperation exception &&
+                exception.Constructor.ContainingNamespace.Name.StartsWith("System", StringComparison.InvariantCulture))
+            {
+                var fullName = $"{exception.Constructor.ContainingNamespace.Name}.{exception.Constructor.ContainingType.Name}";
+                if (fullName != typeof(NotImplementedException).FullName)
                 {
-                    var fullName = $"{exception.Constructor.ContainingNamespace.Name}.{exception.Constructor.ContainingType.Name}";
-                    if (fullName != typeof(NotImplementedException).FullName)
-                    {
-                        var diagnostic = Diagnostic.Create(Rule, throwOperation.Syntax.GetLocation());
-                        context.ReportDiagnostic(diagnostic);
-                    }
+                    var diagnostic = Diagnostic.Create(Rule, throwOperation.Syntax.GetLocation());
+                    context.ReportDiagnostic(diagnostic);
                 }
             }
         }

--- a/Source/CodeAnalysis/ExceptionShouldNotBeSuffixed/Analyzer.cs
+++ b/Source/CodeAnalysis/ExceptionShouldNotBeSuffixed/Analyzer.cs
@@ -1,49 +1,51 @@
-﻿namespace Aksio.CodeAnalysis.ExceptionShouldNotBeSuffixed
+﻿// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionShouldNotBeSuffixed;
+
+/// <summary>
+/// Represents a <see cref="DiagnosticAnalyzer"/> that does requires one to now add a suffix of 'Exception' to an exception type - indicating possibly bad naming.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : DiagnosticAnalyzer
 {
     /// <summary>
-    /// Represents a <see cref="DiagnosticAnalyzer"/> that does requires one to now add a suffix of 'Exception' to an exception type - indicating possibly bad naming.
+    /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : DiagnosticAnalyzer
+    public static readonly DiagnosticDescriptor Rule = new(
+         id: "AS0004",
+         title: "ExceptionShouldNotBeSuffixed",
+         messageFormat: "The use of the word 'Exception' should not be added as a suffix - create a well understood and self explanatory name for the exception",
+         category: "Naming",
+         defaultSeverity: DiagnosticSeverity.Error,
+         isEnabledByDefault: true,
+         description: null,
+         helpLinkUri: string.Empty,
+         customTags: Array.Empty<string>());
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
     {
-        /// <summary>
-        /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
-        /// </summary>
-        public static readonly DiagnosticDescriptor Rule = new (
-             id: "AS0004",
-             title: "ExceptionShouldNotBeSuffixed",
-             messageFormat: "The use of the word 'Exception' should not be added as a suffix - create a well understood and self explanatory name for the exception",
-             category: "Naming",
-             defaultSeverity: DiagnosticSeverity.Error,
-             isEnabledByDefault: true,
-             description: null,
-             helpLinkUri: string.Empty,
-             customTags: Array.Empty<string>());
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(
+            HandleClassDeclaration,
+            ImmutableArray.Create(
+                SyntaxKind.ClassDeclaration));
+    }
 
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    void HandleClassDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var classDeclaration = context.Node as ClassDeclarationSyntax;
+        if (classDeclaration?.BaseList == null || classDeclaration?.BaseList?.Types == null) return;
 
-        /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        if (classDeclaration.InheritsASystemException(context.SemanticModel) && classDeclaration.Identifier.Text.EndsWith("Exception", StringComparison.InvariantCulture))
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-            context.RegisterSyntaxNodeAction(
-                HandleClassDeclaration,
-                ImmutableArray.Create(
-                    SyntaxKind.ClassDeclaration));
-        }
-
-        void HandleClassDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var classDeclaration = context.Node as ClassDeclarationSyntax;
-            if (classDeclaration?.BaseList == null || classDeclaration?.BaseList?.Types == null) return;
-
-            if (classDeclaration.InheritsASystemException(context.SemanticModel) && classDeclaration.Identifier.Text.EndsWith("Exception", StringComparison.InvariantCulture))
-            {
-                var diagnostic = Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation());
-                context.ReportDiagnostic(diagnostic);
-            }
+            var diagnostic = Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation());
+            context.ReportDiagnostic(diagnostic);
         }
     }
 }

--- a/Source/CodeAnalysis/Extensions.cs
+++ b/Source/CodeAnalysis/Extensions.cs
@@ -1,50 +1,52 @@
-namespace Aksio.CodeAnalysis
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis;
+
+/// <summary>
+/// General extension methods for code analysis.
+/// </summary>
+public static class Extensions
 {
     /// <summary>
-    /// General extension methods for code analysis.
+    /// Check if a <see cref="ClassDeclarationSyntax"/> inherits a System Exception.
     /// </summary>
-    public static class Extensions
+    /// <param name="classDeclaration"><see cref="ClassDeclarationSyntax"/> to check.</param>
+    /// <param name="model"><see cref="SemanticModel"/> to use.</param>
+    /// <returns>true if it inherits, false if not.</returns>
+    public static bool InheritsASystemException(this ClassDeclarationSyntax classDeclaration, SemanticModel model)
     {
-        /// <summary>
-        /// Check if a <see cref="ClassDeclarationSyntax"/> inherits a System Exception.
-        /// </summary>
-        /// <param name="classDeclaration"><see cref="ClassDeclarationSyntax"/> to check.</param>
-        /// <param name="model"><see cref="SemanticModel"/> to use.</param>
-        /// <returns>true if it inherits, false if not.</returns>
-        public static bool InheritsASystemException(this ClassDeclarationSyntax classDeclaration, SemanticModel model)
+        var classSymbol = model.GetDeclaredSymbol(classDeclaration);
+        return classSymbol.BaseType.ContainingNamespace.Name.StartsWith("System", StringComparison.InvariantCulture) &&
+            classSymbol.BaseType.Name.EndsWith("Exception", StringComparison.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Check if a <see cref="ClassDeclarationSyntax"/> is an attribute.
+    /// </summary>
+    /// <param name="classDeclaration"><see cref="ClassDeclarationSyntax"/> to check.</param>
+    /// <param name="model"><see cref="SemanticModel"/> to use.</param>
+    /// <returns>true if it is, false if not.</returns>
+    public static bool IsAttribute(this ClassDeclarationSyntax classDeclaration, SemanticModel model)
+    {
+        var classSymbol = model.GetDeclaredSymbol(classDeclaration);
+        var baseType = classSymbol.BaseType;
+        if (baseType == default)
         {
-            var classSymbol = model.GetDeclaredSymbol(classDeclaration);
-            return classSymbol.BaseType.ContainingNamespace.Name.StartsWith("System", StringComparison.InvariantCulture) &&
-                classSymbol.BaseType.Name.EndsWith("Exception", StringComparison.InvariantCulture);
-        }
-
-        /// <summary>
-        /// Check if a <see cref="ClassDeclarationSyntax"/> is an attribute.
-        /// </summary>
-        /// <param name="classDeclaration"><see cref="ClassDeclarationSyntax"/> to check.</param>
-        /// <param name="model"><see cref="SemanticModel"/> to use.</param>
-        /// <returns>true if it is, false if not.</returns>
-        public static bool IsAttribute(this ClassDeclarationSyntax classDeclaration, SemanticModel model)
-        {
-            var classSymbol = model.GetDeclaredSymbol(classDeclaration);
-            var baseType = classSymbol.BaseType;
-            if (baseType == default)
-            {
-                return false;
-            }
-
-            while (!(baseType.ContainingNamespace.Name == "System" && baseType.Name == "Object"))
-            {
-                if (baseType.ContainingNamespace.Name.StartsWith("System", StringComparison.InvariantCulture) &&
-                    baseType.Name.EndsWith("Attribute", StringComparison.InvariantCulture))
-                {
-                    return true;
-                }
-
-                baseType = baseType.BaseType;
-            }
-
             return false;
         }
+
+        while (!(baseType.ContainingNamespace.Name == "System" && baseType.Name == "Object"))
+        {
+            if (baseType.ContainingNamespace.Name.StartsWith("System", StringComparison.InvariantCulture) &&
+                baseType.Name.EndsWith("Attribute", StringComparison.InvariantCulture))
+            {
+                return true;
+            }
+
+            baseType = baseType.BaseType;
+        }
+
+        return false;
     }
 }

--- a/Source/CodeAnalysis/GlobalUsings.cs
+++ b/Source/CodeAnalysis/GlobalUsings.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 global using System;
 global using System.Collections.Generic;
 global using System.Collections.Immutable;

--- a/Source/CodeAnalysis/PrivateNotAllowed/Analyzer.cs
+++ b/Source/CodeAnalysis/PrivateNotAllowed/Analyzer.cs
@@ -1,75 +1,77 @@
-﻿namespace Aksio.CodeAnalysis.PrivateNotAllowed
+﻿// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.PrivateNotAllowed;
+
+/// <summary>
+/// Represents a <see cref="DiagnosticAnalyzer"/> that does not allow the use of 'private' keyword.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : DiagnosticAnalyzer
 {
     /// <summary>
-    /// Represents a <see cref="DiagnosticAnalyzer"/> that does not allow the use of 'private' keyword.
+    /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : DiagnosticAnalyzer
+    public static readonly DiagnosticDescriptor Rule = new(
+         id: "AS0002",
+         title: "PrivateNotAllowed",
+         messageFormat: "Private is implicit in C# and is not needed",
+         category: "Style",
+         defaultSeverity: DiagnosticSeverity.Error,
+         isEnabledByDefault: true,
+         description: null,
+         helpLinkUri: string.Empty,
+         customTags: Array.Empty<string>());
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
     {
-        /// <summary>
-        /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
-        /// </summary>
-        public static readonly DiagnosticDescriptor Rule = new (
-             id: "AS0002",
-             title: "PrivateNotAllowed",
-             messageFormat: "Private is implicit in C# and is not needed",
-             category: "Style",
-             defaultSeverity: DiagnosticSeverity.Error,
-             isEnabledByDefault: true,
-             description: null,
-             helpLinkUri: string.Empty,
-             customTags: Array.Empty<string>());
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(
+            HandleDeclarations,
+            ImmutableArray.Create(
+                SyntaxKind.ClassDeclaration,
+                SyntaxKind.MethodDeclaration,
+                SyntaxKind.FieldDeclaration));
 
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        context.RegisterSyntaxNodeAction(
+            HandleEventDeclaration,
+            ImmutableArray.Create(SyntaxKind.EventDeclaration));
 
-        /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
-        {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-            context.RegisterSyntaxNodeAction(
-                HandleDeclarations,
-                ImmutableArray.Create(
-                    SyntaxKind.ClassDeclaration,
-                    SyntaxKind.MethodDeclaration,
-                    SyntaxKind.FieldDeclaration));
+        context.RegisterSyntaxNodeAction(
+            HandlePropertyDeclaration,
+            ImmutableArray.Create(SyntaxKind.PropertyDeclaration));
+    }
 
-            context.RegisterSyntaxNodeAction(
-                HandleEventDeclaration,
-                ImmutableArray.Create(SyntaxKind.EventDeclaration));
+    void HandleDeclarations(SyntaxNodeAnalysisContext context)
+    {
+        var childTokens = context.Node?.ChildTokens();
+        if (childTokens == null) return;
+        ReportErrorIfModifierIsPrivate(context, childTokens);
+    }
 
-            context.RegisterSyntaxNodeAction(
-                HandlePropertyDeclaration,
-                ImmutableArray.Create(SyntaxKind.PropertyDeclaration));
-        }
+    void HandleEventDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var eventDeclaration = context.Node as EventDeclarationSyntax;
+        ReportErrorIfModifierIsPrivate(context, eventDeclaration.Modifiers);
+    }
 
-        void HandleDeclarations(SyntaxNodeAnalysisContext context)
-        {
-            var childTokens = context.Node?.ChildTokens();
-            if (childTokens == null) return;
-            ReportErrorIfModifierIsPrivate(context, childTokens);
-        }
+    void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var propertyDeclaration = context.Node as PropertyDeclarationSyntax;
+        ReportErrorIfModifierIsPrivate(context, propertyDeclaration.Modifiers);
+    }
 
-        void HandleEventDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var eventDeclaration = context.Node as EventDeclarationSyntax;
-            ReportErrorIfModifierIsPrivate(context, eventDeclaration.Modifiers);
-        }
+    void ReportErrorIfModifierIsPrivate(SyntaxNodeAnalysisContext context, IEnumerable<SyntaxToken> tokens)
+    {
+        var privateKeyword = tokens.SingleOrDefault(_ => _.IsKind(SyntaxKind.PrivateKeyword));
+        if (privateKeyword == default) return;
 
-        void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var propertyDeclaration = context.Node as PropertyDeclarationSyntax;
-            ReportErrorIfModifierIsPrivate(context, propertyDeclaration.Modifiers);
-        }
-
-        void ReportErrorIfModifierIsPrivate(SyntaxNodeAnalysisContext context, IEnumerable<SyntaxToken> tokens)
-        {
-            var privateKeyword = tokens.SingleOrDefault(_ => _.IsKind(SyntaxKind.PrivateKeyword));
-            if (privateKeyword == default) return;
-
-            var diagnostic = Diagnostic.Create(Rule, privateKeyword.GetLocation());
-            context.ReportDiagnostic(diagnostic);
-        }
+        var diagnostic = Diagnostic.Create(Rule, privateKeyword.GetLocation());
+        context.ReportDiagnostic(diagnostic);
     }
 }

--- a/Source/CodeAnalysis/RemoveUnnecessaryImports/Analyzer.cs
+++ b/Source/CodeAnalysis/RemoveUnnecessaryImports/Analyzer.cs
@@ -1,55 +1,57 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma warning disable RS1025, RS1026, RS1029
 
-namespace Aksio.CodeAnalysis.RemoveUnnecessaryImports
+namespace Aksio.CodeAnalysis.RemoveUnnecessaryImports;
+
+/// <summary>
+/// Represents a <see cref="DiagnosticAnalyzer"/> that does not allow the unnecessary import statements.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : DiagnosticAnalyzer
 {
     /// <summary>
-    /// Represents a <see cref="DiagnosticAnalyzer"/> that does not allow the unnecessary import statements.
+    /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : DiagnosticAnalyzer
+    public static readonly DiagnosticDescriptor Rule = new(
+         id: "CS8019",
+         title: "RemoveUnnecessaryImports",
+         messageFormat: "Unnecessary using directive",
+         category: "Style",
+         defaultSeverity: DiagnosticSeverity.Error,
+         isEnabledByDefault: true,
+         description: null,
+         helpLinkUri: string.Empty,
+         customTags: Array.Empty<string>());
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
     {
-        /// <summary>
-        /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
-        /// </summary>
-        public static readonly DiagnosticDescriptor Rule = new (
-             id: "CS8019",
-             title: "RemoveUnnecessaryImports",
-             messageFormat: "Unnecessary using directive",
-             category: "Style",
-             defaultSeverity: DiagnosticSeverity.Error,
-             isEnabledByDefault: true,
-             description: null,
-             helpLinkUri: string.Empty,
-             customTags: Array.Empty<string>());
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        context.RegisterSemanticModelAction(AnalyzeSemanticModel);
+    }
 
-        /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+    void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
+    {
+        var cancellationToken = context.CancellationToken;
+        var model = context.SemanticModel;
+        var root = model.SyntaxTree.GetRoot(cancellationToken);
+
+        var diagnostics = model.GetDiagnostics(cancellationToken: cancellationToken);
+        if (!diagnostics.Any()) return;
+
+        foreach (var diagnostic in diagnostics)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-            context.RegisterSemanticModelAction(AnalyzeSemanticModel);
-        }
-
-        void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
-        {
-            var cancellationToken = context.CancellationToken;
-            var model = context.SemanticModel;
-            var root = model.SyntaxTree.GetRoot(cancellationToken);
-
-            var diagnostics = model.GetDiagnostics(cancellationToken: cancellationToken);
-            if (!diagnostics.Any()) return;
-
-            foreach (var diagnostic in diagnostics)
+            if (diagnostic.Id == "CS8019" && root.FindNode(diagnostic.Location.SourceSpan) is UsingDirectiveSyntax node)
             {
-                if (diagnostic.Id == "CS8019" && root.FindNode(diagnostic.Location.SourceSpan) is UsingDirectiveSyntax node)
-                {
-                    var diagnosticWrapper = Diagnostic.Create(Rule, node.GetLocation());
-                    context.ReportDiagnostic(diagnosticWrapper);
-                }
+                var diagnosticWrapper = Diagnostic.Create(Rule, node.GetLocation());
+                context.ReportDiagnostic(diagnosticWrapper);
             }
         }
     }

--- a/Source/CodeAnalysis/SerializableNotAllowed/Analyzer.cs
+++ b/Source/CodeAnalysis/SerializableNotAllowed/Analyzer.cs
@@ -1,44 +1,46 @@
-﻿namespace Aksio.CodeAnalysis.SerializableNotAllowed
+﻿// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.SerializableNotAllowed;
+
+/// <summary>
+/// Represents a <see cref="DiagnosticAnalyzer"/> that does not allow the use of <see cref="SerializableAttribute"/>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Analyzer : DiagnosticAnalyzer
 {
     /// <summary>
-    /// Represents a <see cref="DiagnosticAnalyzer"/> that does not allow the use of <see cref="SerializableAttribute"/>.
+    /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class Analyzer : DiagnosticAnalyzer
+    public static readonly DiagnosticDescriptor Rule = new(
+         id: "AS0001",
+         title: "SerializableNotAllowed",
+         messageFormat: "The use of the [Serializable] attribute is considered an old .NET desktop framework practice for interop/marshalling between AppDomains and is not necessary",
+         category: "Legacy",
+         defaultSeverity: DiagnosticSeverity.Error,
+         isEnabledByDefault: true,
+         description: null,
+         helpLinkUri: string.Empty,
+         customTags: Array.Empty<string>());
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
     {
-        /// <summary>
-        /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
-        /// </summary>
-        public static readonly DiagnosticDescriptor Rule = new (
-             id: "AS0001",
-             title: "SerializableNotAllowed",
-             messageFormat: "The use of the [Serializable] attribute is considered an old .NET desktop framework practice for interop/marshalling between AppDomains and is not necessary",
-             category: "Legacy",
-             defaultSeverity: DiagnosticSeverity.Error,
-             isEnabledByDefault: true,
-             description: null,
-             helpLinkUri: string.Empty,
-             customTags: Array.Empty<string>());
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.Attribute);
+    }
 
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
-
-        /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+    void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
+    {
+        var attribute = context.Node as AttributeSyntax;
+        if (attribute?.Name.ToString() == "Serializable")
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-            context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.Attribute);
-        }
-
-        void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
-        {
-            var attribute = context.Node as AttributeSyntax;
-            if (attribute?.Name.ToString() == "Serializable")
-            {
-                var diagnostic = Diagnostic.Create(Rule, context.Node.GetLocation());
-                context.ReportDiagnostic(diagnostic);
-            }
+            var diagnostic = Diagnostic.Create(Rule, context.Node.GetLocation());
+            context.ReportDiagnostic(diagnostic);
         }
     }
 }

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -6,6 +6,8 @@
     <!-- Meziantou Rules : https://github.com/meziantou/Meziantou.Analyzer/tree/main/docs -->
    
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+        <Rule Id="CS1998" Action="Error" />
+        <Rule Id="CS4014" Action="Error" />
         <Rule Id="SA0001" Action="None" />
         <Rule Id="SA1009" Action="None" />
         <Rule Id="SA1012" Action="None" />

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -6,6 +6,7 @@
     <!-- Meziantou Rules : https://github.com/meziantou/Meziantou.Analyzer/tree/main/docs -->
    
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+        <Rule Id="CS0103" Action="None" />
         <Rule Id="CS1998" Action="Error" />
         <Rule Id="CS4014" Action="Error" />
         <Rule Id="SA0001" Action="None" />

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -4,8 +4,6 @@
     <!-- Rule set reference : https://docs.microsoft.com/en-us/visualstudio/code-quality/rule-set-reference?view=vs-2019 -->
     <!-- Rule set groups : https://docs.microsoft.com/en-us/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules?view=vs-2019 -->
     <!-- Meziantou Rules : https://github.com/meziantou/Meziantou.Analyzer/tree/main/docs -->
-
-    <Include Path="code_analysis_base.ruleset" Action="Default"/>
    
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
         <Rule Id="SA0001" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -6,6 +6,8 @@
     <!-- Meziantou Rules : https://github.com/meziantou/Meziantou.Analyzer/tree/main/docs -->
 
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+        <Rule Id="CS1998" Action="Error" />
+        <Rule Id="CS4014" Action="Error" />
         <Rule Id="SA1000" Action="None" />
         <Rule Id="SA1009" Action="None" />
         <Rule Id="SA1101" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -6,6 +6,7 @@
     <!-- Meziantou Rules : https://github.com/meziantou/Meziantou.Analyzer/tree/main/docs -->
 
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+        <Rule Id="CS0103" Action="None" />
         <Rule Id="CS1998" Action="Error" />
         <Rule Id="CS4014" Action="Error" />
         <Rule Id="SA1000" Action="None" />

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Common.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Common.cs
@@ -1,8 +1,11 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder;
+
+public static class Common
 {
-    public static class Common
-    {
-        public const string ValidOrder = @"
+    public const string ValidOrder = @"
                 class Blabla
                 {
                     string _someBacking;
@@ -35,5 +38,4 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder
                     int TellerPlus1 => Teller+1;
                 }   
             ";
-    }
 }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Constructors/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Constructors/UnitTests.cs
@@ -1,17 +1,20 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
-{
-    public class UnitTests : CodeFixVerifier
-    {
-        [Fact]
-        public void CorrectOrder()
-        {
-            VerifyCSharpDiagnostic(Common.ValidOrder);
-        }
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        [Fact]
-        public void ConstructorBeforeFields()
-        {
-            const string content = @"
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors;
+
+public class UnitTests : CodeFixVerifier
+{
+    [Fact]
+    public void CorrectOrder()
+    {
+        VerifyCSharpDiagnostic(Common.ValidOrder);
+    }
+
+    [Fact]
+    public void ConstructorBeforeFields()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public Blabla() { }
@@ -20,13 +23,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void ConstructorBeforeProperties()
-        {
-            const string content = @"
+    [Fact]
+    public void ConstructorBeforeProperties()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public Blabla() { }
@@ -35,13 +38,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void ConstructorBeforeEvents()
-        {
-            const string content = @"
+    [Fact]
+    public void ConstructorBeforeEvents()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public Blabla() { }
@@ -50,13 +53,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void ConstructorAfterFinalizer()
-        {
-            const string content = @"
+    [Fact]
+    public void ConstructorAfterFinalizer()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() { }
@@ -65,13 +68,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void ConstructorAfterIndexers()
-        {
-            const string content = @"
+    [Fact]
+    public void ConstructorAfterIndexers()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 42;
@@ -80,13 +83,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void ConstructorAfterMethods()
-        {
-            const string content = @"
+    [Fact]
+    public void ConstructorAfterMethods()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => throw new NotImplementedException();
@@ -95,36 +98,35 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Constructors
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void AnalyzerDoesNotCrashOnEmptyClass()
-        {
-            const string content = @"
+    [Fact]
+    public void AnalyzerDoesNotCrashOnEmptyClass()
+    {
+        const string content = @"
                 class Blabla
                 {
                 }
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
+    }
 
-        DiagnosticResult GetExpectedFailure(int failLine = 4)
+    DiagnosticResult GetExpectedFailure(int failLine = 4)
+    {
+        var analyzer = new Analyzer();
+        return new DiagnosticResult
         {
-            var analyzer = new Analyzer();
-            return new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
-            };
-        }
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
+        };
     }
 }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Delegates/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Delegates/UnitTests.cs
@@ -1,17 +1,20 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
-{
-    public class UnitTests: CodeFixVerifier
-    {
-        [Fact]
-        public void CorrectOrder()
-        {
-            VerifyCSharpDiagnostic(Common.ValidOrder);
-        }
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        [Fact]
-        public void DelegatesBeforeFields()
-        {
-            const string content = @"
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates;
+
+public class UnitTests : CodeFixVerifier
+{
+    [Fact]
+    public void CorrectOrder()
+    {
+        VerifyCSharpDiagnostic(Common.ValidOrder);
+    }
+
+    [Fact]
+    public void DelegatesBeforeFields()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public delegate void SomethingHappenedEventHandler(object sender, object args);
@@ -20,13 +23,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void DelegatesBeforeProperties()
-        {
-            const string content = @"
+    [Fact]
+    public void DelegatesBeforeProperties()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public delegate void SomethingHappenedEventHandler(object sender, object args);
@@ -35,13 +38,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void DelegatesAfterEvents()
-        {
-            const string content = @"
+    [Fact]
+    public void DelegatesAfterEvents()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public event EventHandler SomethingHappened;
@@ -50,13 +53,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void DelegatesAfterConstructor()
-        {
-            const string content = @"
+    [Fact]
+    public void DelegatesAfterConstructor()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public Blabla() { }
@@ -65,13 +68,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void DelegatesAfterFinalizer()
-        {
-            const string content = @"
+    [Fact]
+    public void DelegatesAfterFinalizer()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() { }
@@ -80,13 +83,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void DelegatesAfterIndexers()
-        {
-            const string content = @"
+    [Fact]
+    public void DelegatesAfterIndexers()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 42;
@@ -95,13 +98,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void DelegatesAfterMethods()
-        {
-            const string content = @"
+    [Fact]
+    public void DelegatesAfterMethods()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => throw new NotImplementedException();
@@ -110,36 +113,35 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Delegates
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void AnalyzerDoesNotCrashOnEmptyClass()
-        {
-            const string content = @"
+    [Fact]
+    public void AnalyzerDoesNotCrashOnEmptyClass()
+    {
+        const string content = @"
                 class Blabla
                 {
                 }
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
+    }
 
-        DiagnosticResult GetExpectedFailure(int failLine = 4)
+    DiagnosticResult GetExpectedFailure(int failLine = 4)
+    {
+        var analyzer = new Analyzer();
+        return new DiagnosticResult
         {
-            var analyzer = new Analyzer();
-            return new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
-            };
-        }
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
+        };
     }
 }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Events/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Events/UnitTests.cs
@@ -1,17 +1,20 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
-{
-    public class UnitTests: CodeFixVerifier
-    {
-        [Fact]
-        public void CorrectOrder()
-        {
-            VerifyCSharpDiagnostic(Common.ValidOrder);
-        }
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        [Fact]
-        public void EventsBeforeFields()
-        {
-            const string content = @"
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events;
+
+public class UnitTests : CodeFixVerifier
+{
+    [Fact]
+    public void CorrectOrder()
+    {
+        VerifyCSharpDiagnostic(Common.ValidOrder);
+    }
+
+    [Fact]
+    public void EventsBeforeFields()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public event EventHandler SomethingHappened;
@@ -20,13 +23,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void EventsBeforeProperties()
-        {
-            const string content = @"
+    [Fact]
+    public void EventsBeforeProperties()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public event EventHandler SomethingHappened;
@@ -35,13 +38,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void EventsBeforeDelegates()
-        {
-            const string content = @"
+    [Fact]
+    public void EventsBeforeDelegates()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public event EventHandler SomethingHappened;
@@ -50,13 +53,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void EventsAfterConstructor()
-        {
-            const string content = @"
+    [Fact]
+    public void EventsAfterConstructor()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public Blabla() { }
@@ -65,13 +68,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void EventsAfterFinalizer()
-        {
-            const string content = @"
+    [Fact]
+    public void EventsAfterFinalizer()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() { }
@@ -80,13 +83,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void EventsAfterIndexers()
-        {
-            const string content = @"
+    [Fact]
+    public void EventsAfterIndexers()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 42;
@@ -95,13 +98,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void EventsAfterMethods()
-        {
-            const string content = @"
+    [Fact]
+    public void EventsAfterMethods()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => throw new NotImplementedException();
@@ -110,36 +113,35 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Events
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void AnalyzerDoesNotCrashOnEmptyClass()
-        {
-            const string content = @"
+    [Fact]
+    public void AnalyzerDoesNotCrashOnEmptyClass()
+    {
+        const string content = @"
                 class Blabla
                 {
                 }
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
+    }
 
-        DiagnosticResult GetExpectedFailure(int failLine = 4)
+    DiagnosticResult GetExpectedFailure(int failLine = 4)
+    {
+        var analyzer = new Analyzer();
+        return new DiagnosticResult
         {
-            var analyzer = new Analyzer();
-            return new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
-            };
-        }
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
+        };
     }
 }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Fields/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Fields/UnitTests.cs
@@ -1,17 +1,20 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
-{
-    public class UnitTests : CodeFixVerifier
-    {
-        [Fact]
-        public void FieldsBeforeConstructor()
-        {
-            VerifyCSharpDiagnostic(Common.ValidOrder);
-        }
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        [Fact]
-        public void FieldsAfterDelegates()
-        {
-            const string content = @"
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields;
+
+public class UnitTests : CodeFixVerifier
+{
+    [Fact]
+    public void FieldsBeforeConstructor()
+    {
+        VerifyCSharpDiagnostic(Common.ValidOrder);
+    }
+
+    [Fact]
+    public void FieldsAfterDelegates()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public delegate void SomethingHappenedEventHandler(object sender, object args);
@@ -20,13 +23,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void FieldsAfterEvents()
-        {
-            const string content = @"
+    [Fact]
+    public void FieldsAfterEvents()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public event EventHandler SomethingHappened;
@@ -35,13 +38,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void FieldsAfterConstructor()
-        {
-            const string content = @"
+    [Fact]
+    public void FieldsAfterConstructor()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public Blabla() {}
@@ -50,13 +53,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void FieldsAfterFinalizer()
-        {
-            const string content = @"
+    [Fact]
+    public void FieldsAfterFinalizer()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() {}
@@ -65,13 +68,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void FieldsAfterIndexers()
-        {
-            const string content = @"
+    [Fact]
+    public void FieldsAfterIndexers()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => Teller;
@@ -80,13 +83,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void FieldsAfterMethods()
-        {
-            const string content = @"
+    [Fact]
+    public void FieldsAfterMethods()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => ++Teller;
@@ -95,38 +98,37 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Fields
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void AnalyzerDoesNotCrashOnEmptyClass()
-        {
-            const string content = @"
+    [Fact]
+    public void AnalyzerDoesNotCrashOnEmptyClass()
+    {
+        const string content = @"
                 class Blabla
                 {
                 }
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
+    }
+
+    DiagnosticResult[] GetExpectedFailures(int firstFailLine = 6)
+    {
+        var analyzer = new Analyzer();
+        var firstFailure = new DiagnosticResult
         {
-            return new Analyzer();
-        }
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", firstFailLine, 21) }
+        };
 
-        DiagnosticResult[] GetExpectedFailures(int firstFailLine = 6)
-        {
-            var analyzer = new Analyzer();
-            var firstFailure = new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", firstFailLine, 21) }
-            };
-
-            return new[] { firstFailure };
-        }
+        return new[] { firstFailure };
     }
 }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Finalizers/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Finalizers/UnitTests.cs
@@ -1,17 +1,20 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
-{
-    public class UnitTests: CodeFixVerifier
-    {
-        [Fact]
-        public void CorrectOrder()
-        {
-            VerifyCSharpDiagnostic(Common.ValidOrder);
-        }
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        [Fact]
-        public void FinalizerBeforeFields()
-        {
-            const string content = @"
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers;
+
+public class UnitTests : CodeFixVerifier
+{
+    [Fact]
+    public void CorrectOrder()
+    {
+        VerifyCSharpDiagnostic(Common.ValidOrder);
+    }
+
+    [Fact]
+    public void FinalizerBeforeFields()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() {}
@@ -20,13 +23,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void FinalizerBeforeProperties()
-        {
-            const string content = @"
+    [Fact]
+    public void FinalizerBeforeProperties()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() {}
@@ -35,13 +38,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void FinalizerBeforeEvents()
-        {
-            const string content = @"
+    [Fact]
+    public void FinalizerBeforeEvents()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() {}
@@ -50,13 +53,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void FinalizerBeforeConstructor()
-        {
-            const string content = @"
+    [Fact]
+    public void FinalizerBeforeConstructor()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() {}
@@ -65,13 +68,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void FinalizerAfterIndexers()
-        {
-            const string content = @"
+    [Fact]
+    public void FinalizerAfterIndexers()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 42;
@@ -80,13 +83,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void FinalizerAfterMethods()
-        {
-            const string content = @"
+    [Fact]
+    public void FinalizerAfterMethods()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => throw new NotImplementedException();
@@ -95,36 +98,35 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Finalizers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void AnalyzerDoesNotCrashOnEmptyClass()
-        {
-            const string content = @"
+    [Fact]
+    public void AnalyzerDoesNotCrashOnEmptyClass()
+    {
+        const string content = @"
                 class Blabla
                 {
                 }
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
+    }
 
-        DiagnosticResult GetExpectedFailure(int failLine = 4)
+    DiagnosticResult GetExpectedFailure(int failLine = 4)
+    {
+        var analyzer = new Analyzer();
+        return new DiagnosticResult
         {
-            var analyzer = new Analyzer();
-            return new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
-            };
-        }
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
+        };
     }
 }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Indexers/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Indexers/UnitTests.cs
@@ -1,17 +1,20 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
-{
-    public class UnitTests : CodeFixVerifier
-    {
-        [Fact]
-        public void CorrectOrder()
-        {
-            VerifyCSharpDiagnostic(Common.ValidOrder);
-        }
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        [Fact]
-        public void IndexerBeforeFields()
-        {
-            const string content = @"
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers;
+
+public class UnitTests : CodeFixVerifier
+{
+    [Fact]
+    public void CorrectOrder()
+    {
+        VerifyCSharpDiagnostic(Common.ValidOrder);
+    }
+
+    [Fact]
+    public void IndexerBeforeFields()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 0;
@@ -20,13 +23,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void IndexerBeforeProperties()
-        {
-            const string content = @"
+    [Fact]
+    public void IndexerBeforeProperties()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 0;
@@ -35,13 +38,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void IndexerBeforeEvents()
-        {
-            const string content = @"
+    [Fact]
+    public void IndexerBeforeEvents()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 0;
@@ -50,13 +53,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void IndexerBeforeConstructor()
-        {
-            const string content = @"
+    [Fact]
+    public void IndexerBeforeConstructor()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 0;
@@ -65,13 +68,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void IndexerBefoerFinalizer()
-        {
-            const string content = @"
+    [Fact]
+    public void IndexerBefoerFinalizer()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => 0;
@@ -80,13 +83,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void IndexerAfterMethods()
-        {
-            const string content = @"
+    [Fact]
+    public void IndexerAfterMethods()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => throw new NotImplementedException();
@@ -95,36 +98,35 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Indexers
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure(6));
+    }
 
-        [Fact]
-        public void AnalyzerDoesNotCrashOnEmptyClass()
-        {
-            const string content = @"
+    [Fact]
+    public void AnalyzerDoesNotCrashOnEmptyClass()
+    {
+        const string content = @"
                 class Blabla
                 {
                 }
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
+    }
 
-        DiagnosticResult GetExpectedFailure(int failLine = 4)
+    DiagnosticResult GetExpectedFailure(int failLine = 4)
+    {
+        var analyzer = new Analyzer();
+        return new DiagnosticResult
         {
-            var analyzer = new Analyzer();
-            return new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
-            };
-        }
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
+        };
     }
 }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Methods/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Methods/UnitTests.cs
@@ -1,17 +1,20 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
-{
-    public class UnitTests : CodeFixVerifier
-    {
-        [Fact]
-        public void CorrectOrder()
-        {
-            VerifyCSharpDiagnostic(Common.ValidOrder);
-        }
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        [Fact]
-        public void MethodsBeforeFields()
-        {
-            const string content = @"
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods;
+
+public class UnitTests : CodeFixVerifier
+{
+    [Fact]
+    public void CorrectOrder()
+    {
+        VerifyCSharpDiagnostic(Common.ValidOrder);
+    }
+
+    [Fact]
+    public void MethodsBeforeFields()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => ++_teller;
@@ -20,13 +23,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void MethodsBeforeProperties()
-        {
-            const string content = @"
+    [Fact]
+    public void MethodsBeforeProperties()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => 42;
@@ -35,13 +38,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void MethodsBeforeDelegates()
-        {
-            const string content = @"
+    [Fact]
+    public void MethodsBeforeDelegates()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => 42;
@@ -50,13 +53,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void MethodsBeforeEvents()
-        {
-            const string content = @"
+    [Fact]
+    public void MethodsBeforeEvents()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => 42;
@@ -65,13 +68,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void MethodsBeforeConstructor()
-        {
-            const string content = @"
+    [Fact]
+    public void MethodsBeforeConstructor()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => 42;
@@ -80,13 +83,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void MethodsBeforeFinalizer()
-        {
-            const string content = @"
+    [Fact]
+    public void MethodsBeforeFinalizer()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => 42;
@@ -95,13 +98,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void MethodsBeforeIndexers()
-        {
-            const string content = @"
+    [Fact]
+    public void MethodsBeforeIndexers()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => ++Teller;
@@ -110,36 +113,35 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Methods
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailure());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailure());
+    }
 
-        [Fact]
-        public void AnalyzerDoesNotCrashOnEmptyClass()
-        {
-            const string content = @"
+    [Fact]
+    public void AnalyzerDoesNotCrashOnEmptyClass()
+    {
+        const string content = @"
                 class Blabla
                 {
                 }
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
+    }
 
-        DiagnosticResult GetExpectedFailure(int failLine = 4)
+    DiagnosticResult GetExpectedFailure(int failLine = 4)
+    {
+        var analyzer = new Analyzer();
+        return new DiagnosticResult
         {
-            var analyzer = new Analyzer();
-            return new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
-            };
-        }
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", failLine, 21) }
+        };
     }
 }

--- a/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ElementsMustAppearInTheCorrectOrder/Properties/UnitTests.cs
@@ -1,17 +1,20 @@
-namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
-{
-    public class UnitTests: CodeFixVerifier
-    {
-        [Fact]
-        public void CorrectOrder()
-        {
-            VerifyCSharpDiagnostic(Common.ValidOrder);
-        }
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-        [Fact]
-        public void PropertiesAfterDelegates()
-        {
-            const string content = @"
+namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties;
+
+public class UnitTests : CodeFixVerifier
+{
+    [Fact]
+    public void CorrectOrder()
+    {
+        VerifyCSharpDiagnostic(Common.ValidOrder);
+    }
+
+    [Fact]
+    public void PropertiesAfterDelegates()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public delegate void SomethingHappenedEventHandler(object sender, object args);
@@ -22,13 +25,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void PropertiesAfterEvents()
-        {
-            const string content = @"
+    [Fact]
+    public void PropertiesAfterEvents()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public event EventHandler SomethingHappened;
@@ -39,13 +42,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void PropertiesAfterConstructor()
-        {
-            const string content = @"
+    [Fact]
+    public void PropertiesAfterConstructor()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public Blabla() { }
@@ -56,13 +59,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void PropertiesAfterFinalizer()
-        {
-            const string content = @"
+    [Fact]
+    public void PropertiesAfterFinalizer()
+    {
+        const string content = @"
                 class Blabla
                 {
                     ~Blabla() { }
@@ -73,13 +76,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void PropertiesAfterIndexers()
-        {
-            const string content = @"
+    [Fact]
+    public void PropertiesAfterIndexers()
+    {
+        const string content = @"
                 class Blabla
                 {
                     public int this[int i] => Teller;
@@ -90,13 +93,13 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
-        [Fact]
-        public void PropertiesAfterMethods()
-        {
-            const string content = @"
+    [Fact]
+    public void PropertiesAfterMethods()
+    {
+        const string content = @"
                 class Blabla
                 {
                     void ØkTeller() => ++Teller;
@@ -107,48 +110,47 @@ namespace Aksio.CodeAnalysis.ElementsMustAppearInTheCorrectOrder.Properties
                 }
             ";
 
-            VerifyCSharpDiagnostic(content, GetExpectedFailures());
-        }
+        VerifyCSharpDiagnostic(content, GetExpectedFailures());
+    }
 
 
-        [Fact]
-        public void AnalyzerDoesNotCrashOnEmptyClass()
-        {
-            const string content = @"
+    [Fact]
+    public void AnalyzerDoesNotCrashOnEmptyClass()
+    {
+        const string content = @"
                 class Blabla
                 {
                 }
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
+    }
+
+    DiagnosticResult[] GetExpectedFailures(int firstFailLine = 7, int secondFailLine = 8)
+    {
+        var analyzer = new Analyzer();
+
+        var firstFailure = new DiagnosticResult
         {
-            return new Analyzer();
-        }
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", firstFailLine, 21) }
+        };
 
-        DiagnosticResult[] GetExpectedFailures(int firstFailLine = 7, int secondFailLine = 8)
+        var secondFailure = new DiagnosticResult
         {
-            var analyzer = new Analyzer();
+            Id = analyzer.Rule.Id,
+            Message = (string)analyzer.Rule.MessageFormat,
+            Severity = analyzer.Rule.DefaultSeverity,
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", secondFailLine, 21) }
+        };
 
-            var firstFailure = new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", firstFailLine, 21) }
-            };
-
-            var secondFailure = new DiagnosticResult
-            {
-                Id = analyzer.Rule.Id,
-                Message = (string)analyzer.Rule.MessageFormat,
-                Severity = analyzer.Rule.DefaultSeverity,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", secondFailLine, 21) }
-            };
-            
-            return new[] { firstFailure, secondFailure };
-        }
+        return new[] { firstFailure, secondFailure };
     }
 }

--- a/Specifications/CodeAnalysis/ExceptionConstructorParametersShouldNotContainMessage/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ExceptionConstructorParametersShouldNotContainMessage/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.ExceptionConstructorParametersShouldNotContainMessage
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionConstructorParametersShouldNotContainMessage;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void WithoutMessageInParameters()
     {
-        [Fact]
-        public void WithoutMessageInParameters()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -19,13 +22,13 @@ namespace Aksio.CodeAnalysis.ExceptionConstructorParametersShouldNotContainMessa
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void WithMessageInConstructorParameters()
-        {
-            const string content = @"
+    [Fact]
+    public void WithMessageInConstructorParameters()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -39,35 +42,35 @@ namespace Aksio.CodeAnalysis.ExceptionConstructorParametersShouldNotContainMessa
                 }       
             ";
 
-            var firstFailure = new DiagnosticResult
+        var firstFailure = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 8, 58)
                 }
-            };
+        };
 
-            var secondFailure = new DiagnosticResult
+        var secondFailure = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 8, 79)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, firstFailure, secondFailure);
-        }
+        VerifyCSharpDiagnostic(content, firstFailure, secondFailure);
+    }
 
-        [Fact]
-        public void WithMessageNotBeingStringInConstructorParameters()
-        {
-            const string content = @"
+    [Fact]
+    public void WithMessageNotBeingStringInConstructorParameters()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -81,12 +84,11 @@ namespace Aksio.CodeAnalysis.ExceptionConstructorParametersShouldNotContainMessa
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/ExceptionDescriptionShouldFollowStandard/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ExceptionDescriptionShouldFollowStandard/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.ExceptionDescriptionShouldFollowStandard
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionDescriptionShouldFollowStandard;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void WithDescriptionFollowingStandard()
     {
-        [Fact]
-        public void WithDescriptionFollowingStandard()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -20,13 +23,13 @@ namespace Aksio.CodeAnalysis.ExceptionDescriptionShouldFollowStandard
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void WithoutDescriptionFollowingStandard()
-        {
-            const string content = @"
+    [Fact]
+    public void WithoutDescriptionFollowingStandard()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -41,23 +44,22 @@ namespace Aksio.CodeAnalysis.ExceptionDescriptionShouldFollowStandard
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 7, 24)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/ExceptionShouldBeSpecific/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ExceptionShouldBeSpecific/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void ThrowingCustomException()
     {
-        [Fact]
-        public void ThrowingCustomException()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -25,13 +28,13 @@ namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void ThrowingException()
-        {
-            const string content = @"
+    [Fact]
+    public void ThrowingException()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -46,24 +49,24 @@ namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 10, 29)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        [Fact]
-        public void ThrowingArgumentException()
-        {
-            const string content = @"
+    [Fact]
+    public void ThrowingArgumentException()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -78,24 +81,24 @@ namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 10, 29)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        [Fact]
-        public void ThrowingNotImplementedException()
-        {
-            const string content = @"
+    [Fact]
+    public void ThrowingNotImplementedException()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -110,12 +113,11 @@ namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/ExceptionShouldNotBeSuffixed/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ExceptionShouldNotBeSuffixed/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.ExceptionShouldNotBeSuffixed
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionShouldNotBeSuffixed;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void WithoutSuffix()
     {
-        [Fact]
-        public void WithoutSuffix()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -17,13 +20,13 @@ namespace Aksio.CodeAnalysis.ExceptionShouldNotBeSuffixed
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void WithSuffix()
-        {
-            const string content = @"
+    [Fact]
+    public void WithSuffix()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -35,23 +38,22 @@ namespace Aksio.CodeAnalysis.ExceptionShouldNotBeSuffixed
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 6, 34)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/ExceptionShouldOnlyHaveOneConstructor/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ExceptionShouldOnlyHaveOneConstructor/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.ExceptionShouldOnlyHaveOneConstructor
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.ExceptionShouldOnlyHaveOneConstructor;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void WithoutConstructor()
     {
-        [Fact]
-        public void WithoutConstructor()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -16,13 +19,13 @@ namespace Aksio.CodeAnalysis.ExceptionShouldOnlyHaveOneConstructor
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void WithSingleConstructor()
-        {
-            const string content = @"
+    [Fact]
+    public void WithSingleConstructor()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -36,13 +39,13 @@ namespace Aksio.CodeAnalysis.ExceptionShouldOnlyHaveOneConstructor
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void WithMultipleConstructors()
-        {
-            const string content = @"
+    [Fact]
+    public void WithMultipleConstructors()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -60,34 +63,33 @@ namespace Aksio.CodeAnalysis.ExceptionShouldOnlyHaveOneConstructor
                 }       
             ";
 
-            var firstFailure = new DiagnosticResult
+        var firstFailure = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 8, 25)
                 }
-            };
+        };
 
-            var secondFailure = new DiagnosticResult
+        var secondFailure = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 12, 25)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, firstFailure, secondFailure);
-        }
+        VerifyCSharpDiagnostic(content, firstFailure, secondFailure);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/Helpers/CodeFixVerifier.Helper.cs
+++ b/Specifications/CodeAnalysis/Helpers/CodeFixVerifier.Helper.cs
@@ -1,78 +1,80 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma warning disable SA1629, SA1116, SA1117, CA2000, SA1124, SA1515, SA1202, SA1513, CA1825, SA1005, SA1202, SA1028, SA1202, CA1829, CA1815
 
-namespace Aksio.CodeAnalysis
+namespace Aksio.CodeAnalysis;
+
+/// <summary>
+/// Diagnostic Producer class with extra methods dealing with applying codefixes
+/// All methods are static
+/// </summary>
+public abstract partial class CodeFixVerifier : DiagnosticVerifier
 {
     /// <summary>
-    /// Diagnostic Producer class with extra methods dealing with applying codefixes
-    /// All methods are static
+    /// Apply the inputted CodeAction to the inputted document.
+    /// Meant to be used to apply codefixes.
     /// </summary>
-    public abstract partial class CodeFixVerifier : DiagnosticVerifier
+    /// <param name="document">The Document to apply the fix on</param>
+    /// <param name="codeAction">A CodeAction that will be applied to the Document.</param>
+    /// <returns>A Document with the changes from the CodeAction</returns>
+    static Document ApplyFix(Document document, CodeAction codeAction)
     {
-        /// <summary>
-        /// Apply the inputted CodeAction to the inputted document.
-        /// Meant to be used to apply codefixes.
-        /// </summary>
-        /// <param name="document">The Document to apply the fix on</param>
-        /// <param name="codeAction">A CodeAction that will be applied to the Document.</param>
-        /// <returns>A Document with the changes from the CodeAction</returns>
-        static Document ApplyFix(Document document, CodeAction codeAction)
+        var operations = codeAction.GetOperationsAsync(CancellationToken.None).Result;
+        var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+        return solution.GetDocument(document.Id);
+    }
+
+    /// <summary>
+    /// Compare two collections of Diagnostics,and return a list of any new diagnostics that appear only in the second collection.
+    /// Note: Considers Diagnostics to be the same if they have the same Ids.  In the case of multiple diagnostics with the same Id in a row,
+    /// this method may not necessarily return the new one.
+    /// </summary>
+    /// <param name="diagnostics">The Diagnostics that existed in the code before the CodeFix was applied</param>
+    /// <param name="newDiagnostics">The Diagnostics that exist in the code after the CodeFix was applied</param>
+    /// <returns>A list of Diagnostics that only surfaced in the code after the CodeFix was applied</returns>
+    static IEnumerable<Diagnostic> GetNewDiagnostics(IEnumerable<Diagnostic> diagnostics, IEnumerable<Diagnostic> newDiagnostics)
+    {
+        var oldArray = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+        var newArray = newDiagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+
+        var oldIndex = 0;
+        var newIndex = 0;
+
+        while (newIndex < newArray.Length)
         {
-            var operations = codeAction.GetOperationsAsync(CancellationToken.None).Result;
-            var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
-            return solution.GetDocument(document.Id);
-        }
-
-        /// <summary>
-        /// Compare two collections of Diagnostics,and return a list of any new diagnostics that appear only in the second collection.
-        /// Note: Considers Diagnostics to be the same if they have the same Ids.  In the case of multiple diagnostics with the same Id in a row,
-        /// this method may not necessarily return the new one.
-        /// </summary>
-        /// <param name="diagnostics">The Diagnostics that existed in the code before the CodeFix was applied</param>
-        /// <param name="newDiagnostics">The Diagnostics that exist in the code after the CodeFix was applied</param>
-        /// <returns>A list of Diagnostics that only surfaced in the code after the CodeFix was applied</returns>
-        static IEnumerable<Diagnostic> GetNewDiagnostics(IEnumerable<Diagnostic> diagnostics, IEnumerable<Diagnostic> newDiagnostics)
-        {
-            var oldArray = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
-            var newArray = newDiagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
-
-            int oldIndex = 0;
-            int newIndex = 0;
-
-            while (newIndex < newArray.Length)
+            if (oldIndex < oldArray.Length && oldArray[oldIndex].Id == newArray[newIndex].Id)
             {
-                if (oldIndex < oldArray.Length && oldArray[oldIndex].Id == newArray[newIndex].Id)
-                {
-                    ++oldIndex;
-                    ++newIndex;
-                }
-                else
-                {
-                    yield return newArray[newIndex++];
-                }
+                ++oldIndex;
+                ++newIndex;
+            }
+            else
+            {
+                yield return newArray[newIndex++];
             }
         }
+    }
 
-        /// <summary>
-        /// Get the existing compiler diagnostics on the inputted document.
-        /// </summary>
-        /// <param name="document">The Document to run the compiler diagnostic analyzers on</param>
-        /// <returns>The compiler diagnostics that were found in the code</returns>
-        static IEnumerable<Diagnostic> GetCompilerDiagnostics(Document document)
-        {
-            return document.GetSemanticModelAsync().Result.GetDiagnostics();
-        }
+    /// <summary>
+    /// Get the existing compiler diagnostics on the inputted document.
+    /// </summary>
+    /// <param name="document">The Document to run the compiler diagnostic analyzers on</param>
+    /// <returns>The compiler diagnostics that were found in the code</returns>
+    static IEnumerable<Diagnostic> GetCompilerDiagnostics(Document document)
+    {
+        return document.GetSemanticModelAsync().Result.GetDiagnostics();
+    }
 
-        /// <summary>
-        /// Given a document, turn it into a string based on the syntax root
-        /// </summary>
-        /// <param name="document">The Document to be converted to a string</param>
-        /// <returns>A string containing the syntax of the Document after formatting</returns>
-        static string GetStringFromDocument(Document document)
-        {
-            var simplifiedDoc = Simplifier.ReduceAsync(document, Simplifier.Annotation).Result;
-            var root = simplifiedDoc.GetSyntaxRootAsync().Result;
-            root = Formatter.Format(root, Formatter.Annotation, simplifiedDoc.Project.Solution.Workspace);
-            return root.GetText().ToString();
-        }
+    /// <summary>
+    /// Given a document, turn it into a string based on the syntax root
+    /// </summary>
+    /// <param name="document">The Document to be converted to a string</param>
+    /// <returns>A string containing the syntax of the Document after formatting</returns>
+    static string GetStringFromDocument(Document document)
+    {
+        var simplifiedDoc = Simplifier.ReduceAsync(document, Simplifier.Annotation).Result;
+        var root = simplifiedDoc.GetSyntaxRootAsync().Result;
+        root = Formatter.Format(root, Formatter.Annotation, simplifiedDoc.Project.Solution.Workspace);
+        return root.GetText().ToString();
     }
 }

--- a/Specifications/CodeAnalysis/Helpers/DiagnosticResult.cs
+++ b/Specifications/CodeAnalysis/Helpers/DiagnosticResult.cs
@@ -1,59 +1,43 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma warning disable SA1629, SA1116, SA1117, CA2000, SA1124, SA1515, SA1202, SA1513, CA1825, SA1005, SA1202, SA1028, SA1202, CA1829, CA1815
 
-namespace Aksio.CodeAnalysis
+namespace Aksio.CodeAnalysis;
+
+/// <summary>
+/// Struct that stores information about a Diagnostic appearing in a source
+/// </summary>
+public struct DiagnosticResult
 {
-    /// <summary>
-    /// Struct that stores information about a Diagnostic appearing in a source
-    /// </summary>
-    public struct DiagnosticResult
+    DiagnosticResultLocation[] locations;
+
+    public DiagnosticResultLocation[] Locations
     {
-        DiagnosticResultLocation[] locations;
-
-        public DiagnosticResultLocation[] Locations
+        get
         {
-            get
+            if (locations == null)
             {
-                if (locations == null)
-                {
-                    locations = new DiagnosticResultLocation[] { };
-                }
-                return locations;
+                locations = new DiagnosticResultLocation[] { };
             }
-
-            set
-            {
-                locations = value;
-            }
+            return locations;
         }
 
-        public DiagnosticSeverity Severity { get; set; }
-
-        public string Id { get; set; }
-
-        public string Message { get; set; }
-
-        public string Path
+        set
         {
-            get
-            {
-                return Locations.Length > 0 ? Locations[0].Path : "";
-            }
-        }
-
-        public int Line
-        {
-            get
-            {
-                return Locations.Length > 0 ? Locations[0].Line : -1;
-            }
-        }
-
-        public int Column
-        {
-            get
-            {
-                return Locations.Length > 0 ? Locations[0].Column : -1;
-            }
+            locations = value;
         }
     }
+
+    public DiagnosticSeverity Severity { get; set; }
+
+    public string Id { get; set; }
+
+    public string Message { get; set; }
+
+    public string Path => Locations.Length > 0 ? Locations[0].Path : "";
+
+    public int Line => Locations.Length > 0 ? Locations[0].Line : -1;
+
+    public int Column => Locations.Length > 0 ? Locations[0].Column : -1;
 }

--- a/Specifications/CodeAnalysis/Helpers/DiagnosticResultLocation.cs
+++ b/Specifications/CodeAnalysis/Helpers/DiagnosticResultLocation.cs
@@ -1,33 +1,35 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma warning disable SA1629, SA1116, SA1117, CA2000, SA1124, SA1515, SA1202, SA1513, CA1825, SA1005, SA1202, SA1028, SA1202, CA1829, CA1815
 
-namespace Aksio.CodeAnalysis
+namespace Aksio.CodeAnalysis;
+
+/// <summary>
+/// Location where the diagnostic appears, as determined by path, line number, and column number.
+/// </summary>
+public struct DiagnosticResultLocation
 {
-    /// <summary>
-    /// Location where the diagnostic appears, as determined by path, line number, and column number.
-    /// </summary>
-    public struct DiagnosticResultLocation
+    public DiagnosticResultLocation(string path, int line, int column)
     {
-        public DiagnosticResultLocation(string path, int line, int column)
+        if (line < -1)
         {
-            if (line < -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(line), "line must be >= -1");
-            }
-
-            if (column < -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(column), "column must be >= -1");
-            }
-
-            Path = path;
-            Line = line;
-            Column = column;
+            throw new ArgumentOutOfRangeException(nameof(line), "line must be >= -1");
         }
 
-        public string Path { get; }
+        if (column < -1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(column), "column must be >= -1");
+        }
 
-        public int Line { get; }
-
-        public int Column { get; }
+        Path = path;
+        Line = line;
+        Column = column;
     }
+
+    public string Path { get; }
+
+    public int Line { get; }
+
+    public int Column { get; }
 }

--- a/Specifications/CodeAnalysis/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Specifications/CodeAnalysis/Helpers/DiagnosticVerifier.Helper.cs
@@ -1,163 +1,164 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma warning disable SA1629, SA1116, SA1117, CA2000, SA1124, SA1515, SA1202, SA1513, CA1825, SA1005, SA1202, SA1028, SA1202, CA1829, CA1815
 
-namespace Aksio.CodeAnalysis
+namespace Aksio.CodeAnalysis;
+
+/// <summary>
+/// Class for turning strings into documents and getting the diagnostics on them
+/// All methods are static
+/// </summary>
+public abstract partial class DiagnosticVerifier
 {
+    static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+    static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+    static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
+    static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+
+    internal static string DefaultFilePathPrefix = "Test";
+    internal static string CSharpDefaultFileExt = "cs";
+    internal static string VisualBasicDefaultExt = "vb";
+    internal static string TestProjectName = "TestProject";
+
+    #region  Get Diagnostics
+
     /// <summary>
-    /// Class for turning strings into documents and getting the diagnostics on them
-    /// All methods are static
+    /// Given classes in the form of strings, their language, and an IDiagnosticAnalyzer to apply to it, return the diagnostics found in the string after converting it to a document.
     /// </summary>
-    public abstract partial class DiagnosticVerifier
+    /// <param name="sources">Classes in the form of strings</param>
+    /// <param name="language">The language the source classes are in</param>
+    /// <param name="analyzer">The analyzer to be run on the sources</param>
+    /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
+    static Diagnostic[] GetSortedDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer)
     {
-        static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
-        static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
-        static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
-        static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+        return GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(sources, language));
+    }
 
-        internal static string DefaultFilePathPrefix = "Test";
-        internal static string CSharpDefaultFileExt = "cs";
-        internal static string VisualBasicDefaultExt = "vb";
-        internal static string TestProjectName = "TestProject";
-
-        #region  Get Diagnostics
-
-        /// <summary>
-        /// Given classes in the form of strings, their language, and an IDiagnosticAnalyzer to apply to it, return the diagnostics found in the string after converting it to a document.
-        /// </summary>
-        /// <param name="sources">Classes in the form of strings</param>
-        /// <param name="language">The language the source classes are in</param>
-        /// <param name="analyzer">The analyzer to be run on the sources</param>
-        /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
-        static Diagnostic[] GetSortedDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer)
+    /// <summary>
+    /// Given an analyzer and a document to apply it to, run the analyzer and gather an array of diagnostics found in it.
+    /// The returned diagnostics are then ordered by location in the source document.
+    /// </summary>
+    /// <param name="analyzer">The analyzer to run on the documents</param>
+    /// <param name="documents">The Documents that the analyzer will be run on</param>
+    /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
+    protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(DiagnosticAnalyzer analyzer, Document[] documents)
+    {
+        var projects = new HashSet<Project>();
+        foreach (var document in documents)
         {
-            return GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(sources, language));
+            projects.Add(document.Project);
         }
 
-        /// <summary>
-        /// Given an analyzer and a document to apply it to, run the analyzer and gather an array of diagnostics found in it.
-        /// The returned diagnostics are then ordered by location in the source document.
-        /// </summary>
-        /// <param name="analyzer">The analyzer to run on the documents</param>
-        /// <param name="documents">The Documents that the analyzer will be run on</param>
-        /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
-        protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(DiagnosticAnalyzer analyzer, Document[] documents)
+        var diagnostics = new List<Diagnostic>();
+        foreach (var project in projects)
         {
-            var projects = new HashSet<Project>();
-            foreach (var document in documents)
+            var compilationWithAnalyzers = project.GetCompilationAsync().Result.WithAnalyzers(ImmutableArray.Create(analyzer));
+            var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
+            foreach (var diag in diags)
             {
-                projects.Add(document.Project);
-            }
-
-            var diagnostics = new List<Diagnostic>();
-            foreach (var project in projects)
-            {
-                var compilationWithAnalyzers = project.GetCompilationAsync().Result.WithAnalyzers(ImmutableArray.Create(analyzer));
-                var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
-                foreach (var diag in diags)
+                if (diag.Location == Location.None || diag.Location.IsInMetadata)
                 {
-                    if (diag.Location == Location.None || diag.Location.IsInMetadata)
+                    diagnostics.Add(diag);
+                }
+                else
+                {
+                    for (var i = 0; i < documents.Length; i++)
                     {
-                        diagnostics.Add(diag);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < documents.Length; i++)
+                        var document = documents[i];
+                        var tree = document.GetSyntaxTreeAsync().Result;
+                        if (tree == diag.Location.SourceTree)
                         {
-                            var document = documents[i];
-                            var tree = document.GetSyntaxTreeAsync().Result;
-                            if (tree == diag.Location.SourceTree)
-                            {
-                                diagnostics.Add(diag);
-                            }
+                            diagnostics.Add(diag);
                         }
                     }
                 }
             }
-
-            var results = SortDiagnostics(diagnostics);
-            diagnostics.Clear();
-            return results;
         }
 
-        /// <summary>
-        /// Sort diagnostics by location in source document
-        /// </summary>
-        /// <param name="diagnostics">The list of Diagnostics to be sorted</param>
-        /// <returns>An IEnumerable containing the Diagnostics in order of Location</returns>
-        static Diagnostic[] SortDiagnostics(IEnumerable<Diagnostic> diagnostics)
-        {
-            return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
-        }
-
-        #endregion
-
-        #region Set up compilation and documents
-        /// <summary>
-        /// Given an array of strings as sources and a language, turn them into a project and return the documents and spans of it.
-        /// </summary>
-        /// <param name="sources">Classes in the form of strings</param>
-        /// <param name="language">The language the source code is in</param>
-        /// <returns>A Tuple containing the Documents produced from the sources and their TextSpans if relevant</returns>
-        static Document[] GetDocuments(string[] sources, string language)
-        {
-            if (language != LanguageNames.CSharp && language != LanguageNames.VisualBasic)
-            {
-                throw new ArgumentException("Unsupported Language");
-            }
-
-            var project = CreateProject(sources, language);
-            var documents = project.Documents.ToArray();
-
-            if (sources.Length != documents.Length)
-            {
-                throw new InvalidOperationException("Amount of sources did not match amount of Documents created");
-            }
-
-            return documents;
-        }
-
-        /// <summary>
-        /// Create a Document from a string through creating a project that contains it.
-        /// </summary>
-        /// <param name="source">Classes in the form of a string</param>
-        /// <param name="language">The language the source code is in</param>
-        /// <returns>A Document created from the source string</returns>
-        protected static Document CreateDocument(string source, string language = LanguageNames.CSharp)
-        {
-            return CreateProject(new[] { source }, language).Documents.First();
-        }
-
-        /// <summary>
-        /// Create a project using the inputted strings as sources.
-        /// </summary>
-        /// <param name="sources">Classes in the form of strings</param>
-        /// <param name="language">The language the source code is in</param>
-        /// <returns>A Project created out of the Documents created from the source strings</returns>
-        static Project CreateProject(string[] sources, string language = LanguageNames.CSharp)
-        {
-            string fileNamePrefix = DefaultFilePathPrefix;
-            string fileExt = language == LanguageNames.CSharp ? CSharpDefaultFileExt : VisualBasicDefaultExt;
-
-            var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
-
-            var solution = new AdhocWorkspace()
-                .CurrentSolution
-                .AddProject(projectId, TestProjectName, TestProjectName, language)
-                .AddMetadataReference(projectId, CorlibReference)
-                .AddMetadataReference(projectId, SystemCoreReference)
-                .AddMetadataReference(projectId, CSharpSymbolsReference)
-                .AddMetadataReference(projectId, CodeAnalysisReference);
-
-            int count = 0;
-            foreach (var source in sources)
-            {
-                var newFileName = fileNamePrefix + count + "." + fileExt;
-                var documentId = DocumentId.CreateNewId(projectId, debugName: newFileName);
-                solution = solution.AddDocument(documentId, newFileName, SourceText.From(source));
-                count++;
-            }
-            return solution.GetProject(projectId);
-        }
-        #endregion
+        var results = SortDiagnostics(diagnostics);
+        diagnostics.Clear();
+        return results;
     }
+
+    /// <summary>
+    /// Sort diagnostics by location in source document
+    /// </summary>
+    /// <param name="diagnostics">The list of Diagnostics to be sorted</param>
+    /// <returns>An IEnumerable containing the Diagnostics in order of Location</returns>
+    static Diagnostic[] SortDiagnostics(IEnumerable<Diagnostic> diagnostics)
+    {
+        return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+    }
+
+    #endregion
+
+    #region Set up compilation and documents
+    /// <summary>
+    /// Given an array of strings as sources and a language, turn them into a project and return the documents and spans of it.
+    /// </summary>
+    /// <param name="sources">Classes in the form of strings</param>
+    /// <param name="language">The language the source code is in</param>
+    /// <returns>A Tuple containing the Documents produced from the sources and their TextSpans if relevant</returns>
+    static Document[] GetDocuments(string[] sources, string language)
+    {
+        if (language != LanguageNames.CSharp && language != LanguageNames.VisualBasic)
+        {
+            throw new ArgumentException("Unsupported Language");
+        }
+
+        var project = CreateProject(sources, language);
+        var documents = project.Documents.ToArray();
+
+        if (sources.Length != documents.Length)
+        {
+            throw new InvalidOperationException("Amount of sources did not match amount of Documents created");
+        }
+
+        return documents;
+    }
+
+    /// <summary>
+    /// Create a Document from a string through creating a project that contains it.
+    /// </summary>
+    /// <param name="source">Classes in the form of a string</param>
+    /// <param name="language">The language the source code is in</param>
+    /// <returns>A Document created from the source string</returns>
+    protected static Document CreateDocument(string source, string language = LanguageNames.CSharp)
+    {
+        return CreateProject(new[] { source }, language).Documents.First();
+    }
+
+    /// <summary>
+    /// Create a project using the inputted strings as sources.
+    /// </summary>
+    /// <param name="sources">Classes in the form of strings</param>
+    /// <param name="language">The language the source code is in</param>
+    /// <returns>A Project created out of the Documents created from the source strings</returns>
+    static Project CreateProject(string[] sources, string language = LanguageNames.CSharp)
+    {
+        var fileNamePrefix = DefaultFilePathPrefix;
+        var fileExt = language == LanguageNames.CSharp ? CSharpDefaultFileExt : VisualBasicDefaultExt;
+
+        var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
+
+        var solution = new AdhocWorkspace()
+            .CurrentSolution
+            .AddProject(projectId, TestProjectName, TestProjectName, language)
+            .AddMetadataReference(projectId, CorlibReference)
+            .AddMetadataReference(projectId, SystemCoreReference)
+            .AddMetadataReference(projectId, CSharpSymbolsReference)
+            .AddMetadataReference(projectId, CodeAnalysisReference);
+
+        var count = 0;
+        foreach (var source in sources)
+        {
+            var newFileName = fileNamePrefix + count + "." + fileExt;
+            var documentId = DocumentId.CreateNewId(projectId, debugName: newFileName);
+            solution = solution.AddDocument(documentId, newFileName, SourceText.From(source));
+            count++;
+        }
+        return solution.GetProject(projectId);
+    }
+    #endregion
 }

--- a/Specifications/CodeAnalysis/PrivateNotAllowed/UnitTests.cs
+++ b/Specifications/CodeAnalysis/PrivateNotAllowed/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.PrivateNotAllowed
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.PrivateNotAllowed;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void PublicClassWithPublicMethodsPropertiesAndFieldsAllAllowed()
     {
-        [Fact]
-        public void PublicClassWithPublicMethodsPropertiesAndFieldsAllAllowed()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -23,13 +26,13 @@ namespace Aksio.CodeAnalysis.PrivateNotAllowed
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void PrivatePropertySetterAllowed()
-        {
-            const string content = @"
+    [Fact]
+    public void PrivatePropertySetterAllowed()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -41,13 +44,13 @@ namespace Aksio.CodeAnalysis.PrivateNotAllowed
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void PrivateClassNotAllowed()
-        {
-            const string content = @"
+    [Fact]
+    public void PrivateClassNotAllowed()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -59,24 +62,24 @@ namespace Aksio.CodeAnalysis.PrivateNotAllowed
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 6, 21)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        [Fact]
-        public void PrivateMethodNotAllowed()
-        {
-            const string content = @"
+    [Fact]
+    public void PrivateMethodNotAllowed()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -91,24 +94,24 @@ namespace Aksio.CodeAnalysis.PrivateNotAllowed
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 8, 25)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        [Fact]
-        public void PrivateFieldNotAllowed()
-        {
-            const string content = @"
+    [Fact]
+    public void PrivateFieldNotAllowed()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -120,24 +123,24 @@ namespace Aksio.CodeAnalysis.PrivateNotAllowed
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 8, 25)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        [Fact]
-        public void PrivatePropertyNotAllowed()
-        {
-            const string content = @"
+    [Fact]
+    public void PrivatePropertyNotAllowed()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -149,24 +152,24 @@ namespace Aksio.CodeAnalysis.PrivateNotAllowed
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 8, 25)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        [Fact]
-        public void PrivateEventNotAllowed()
-        {
-            const string content = @"
+    [Fact]
+    public void PrivateEventNotAllowed()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -178,23 +181,22 @@ namespace Aksio.CodeAnalysis.PrivateNotAllowed
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 8, 25)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/RemoveUnnecessaryImports/UnitTests.cs
+++ b/Specifications/CodeAnalysis/RemoveUnnecessaryImports/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.RemoveUnnecessaryImports
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.RemoveUnnecessaryImports;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void NotUsingAllImports()
     {
-        [Fact]
-        public void NotUsingAllImports()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -16,23 +19,22 @@ namespace Aksio.CodeAnalysis.RemoveUnnecessaryImports
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 2, 17)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/SealedNotAllowed/UnitTests.cs
+++ b/Specifications/CodeAnalysis/SealedNotAllowed/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.SealedNotAllowed
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.SealedNotAllowed;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void WithoutSealed()
     {
-        [Fact]
-        public void WithoutSealed()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -17,13 +20,13 @@ namespace Aksio.CodeAnalysis.SealedNotAllowed
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void WithSealed()
-        {
-            const string content = @"
+    [Fact]
+    public void WithSealed()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -35,24 +38,24 @@ namespace Aksio.CodeAnalysis.SealedNotAllowed
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 6, 28)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        [Fact]
-        public void WithSealedAttribute()
-        {
-            const string content = @"
+    [Fact]
+    public void WithSealedAttribute()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -63,24 +66,22 @@ namespace Aksio.CodeAnalysis.SealedNotAllowed
                     }
                 }       
             ";
-
-            var expected = new DiagnosticResult
+        _ = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 6, 28)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/SerializableNotAllowed/UnitTests.cs
+++ b/Specifications/CodeAnalysis/SerializableNotAllowed/UnitTests.cs
@@ -1,11 +1,14 @@
-namespace Aksio.CodeAnalysis.SerializableNotAllowed
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.CodeAnalysis.SerializableNotAllowed;
+
+public class UnitTests : CodeFixVerifier
 {
-    public class UnitTests : CodeFixVerifier
+    [Fact]
+    public void WithoutSerializable()
     {
-        [Fact]
-        public void WithoutSerializable()
-        {
-            const string content = @"
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -17,13 +20,13 @@ namespace Aksio.CodeAnalysis.SerializableNotAllowed
                 }       
             ";
 
-            VerifyCSharpDiagnostic(content);
-        }
+        VerifyCSharpDiagnostic(content);
+    }
 
-        [Fact]
-        public void WithSerializable()
-        {
-            const string content = @"
+    [Fact]
+    public void WithSerializable()
+    {
+        const string content = @"
                 using System;
 
                 namespace MyNamespace
@@ -36,23 +39,22 @@ namespace Aksio.CodeAnalysis.SerializableNotAllowed
                 }       
             ";
 
-            var expected = new DiagnosticResult
+        var expected = new DiagnosticResult
+        {
+            Id = Analyzer.Rule.Id,
+            Message = (string)Analyzer.Rule.MessageFormat,
+            Severity = Analyzer.Rule.DefaultSeverity,
+            Locations = new[]
             {
-                Id = Analyzer.Rule.Id,
-                Message = (string)Analyzer.Rule.MessageFormat,
-                Severity = Analyzer.Rule.DefaultSeverity,
-                Locations = new[]
-                {
                     new DiagnosticResultLocation("Test0.cs", 6, 22)
                 }
-            };
+        };
 
-            VerifyCSharpDiagnostic(content, expected);
-        }
+        VerifyCSharpDiagnostic(content, expected);
+    }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return new Analyzer();
-        }
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+    {
+        return new Analyzer();
     }
 }

--- a/Specifications/CodeAnalysis/Verifiers/CodeFixVerifier.cs
+++ b/Specifications/CodeAnalysis/Verifiers/CodeFixVerifier.cs
@@ -1,120 +1,122 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma warning disable SA1629, SA1116, SA1117, CA2000, SA1124, SA1515, SA1202, SA1513, CA1825, SA1005, SA1202, SA1028, SA1202, CA1829, CA1815
 
-namespace Aksio.CodeAnalysis
+namespace Aksio.CodeAnalysis;
+
+/// <summary>
+/// Superclass of all Unit tests made for diagnostics with codefixes.
+/// Contains methods used to verify correctness of codefixes
+/// </summary>
+public abstract partial class CodeFixVerifier : DiagnosticVerifier
 {
     /// <summary>
-    /// Superclass of all Unit tests made for diagnostics with codefixes.
-    /// Contains methods used to verify correctness of codefixes
+    /// Returns the codefix being tested (C#) - to be implemented in non-abstract class
     /// </summary>
-    public abstract partial class CodeFixVerifier : DiagnosticVerifier
+    /// <returns>The CodeFixProvider to be used for CSharp code</returns>
+    protected virtual CodeFixProvider GetCSharpCodeFixProvider()
     {
-        /// <summary>
-        /// Returns the codefix being tested (C#) - to be implemented in non-abstract class
-        /// </summary>
-        /// <returns>The CodeFixProvider to be used for CSharp code</returns>
-        protected virtual CodeFixProvider GetCSharpCodeFixProvider()
-        {
-            return null;
-        }
+        return null;
+    }
 
-        /// <summary>
-        /// Returns the codefix being tested (VB) - to be implemented in non-abstract class
-        /// </summary>
-        /// <returns>The CodeFixProvider to be used for VisualBasic code</returns>
-        protected virtual CodeFixProvider GetBasicCodeFixProvider()
-        {
-            return null;
-        }
+    /// <summary>
+    /// Returns the codefix being tested (VB) - to be implemented in non-abstract class
+    /// </summary>
+    /// <returns>The CodeFixProvider to be used for VisualBasic code</returns>
+    protected virtual CodeFixProvider GetBasicCodeFixProvider()
+    {
+        return null;
+    }
 
-        /// <summary>
-        /// Called to test a C# codefix when applied on the inputted string as a source
-        /// </summary>
-        /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
-        /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
-        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
-        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
-        protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
-        {
-            VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
-        }
+    /// <summary>
+    /// Called to test a C# codefix when applied on the inputted string as a source
+    /// </summary>
+    /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
+    /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
+    /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
+    /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+    protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
+    {
+        VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
+    }
 
-        /// <summary>
-        /// Called to test a VB codefix when applied on the inputted string as a source
-        /// </summary>
-        /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
-        /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
-        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
-        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
-        protected void VerifyBasicFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
-        {
-            VerifyFix(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
-        }
+    /// <summary>
+    /// Called to test a VB codefix when applied on the inputted string as a source
+    /// </summary>
+    /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
+    /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
+    /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
+    /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+    protected void VerifyBasicFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
+    {
+        VerifyFix(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
+    }
 
-        /// <summary>
-        /// General verifier for codefixes.
-        /// Creates a Document from the source string, then gets diagnostics on it and applies the relevant codefixes.
-        /// Then gets the string after the codefix is applied and compares it with the expected result.
-        /// Note: If any codefix causes new diagnostics to show up, the test fails unless allowNewCompilerDiagnostics is set to true.
-        /// </summary>
-        /// <param name="language">The language the source code is in</param>
-        /// <param name="analyzer">The analyzer to be applied to the source code</param>
-        /// <param name="codeFixProvider">The codefix to be applied to the code wherever the relevant Diagnostic is found</param>
-        /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
-        /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
-        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
-        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
-        void VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
-        {
-            var document = CreateDocument(oldSource, language);
-            var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });
-            var compilerDiagnostics = GetCompilerDiagnostics(document);
-            var attempts = analyzerDiagnostics.Length;
+    /// <summary>
+    /// General verifier for codefixes.
+    /// Creates a Document from the source string, then gets diagnostics on it and applies the relevant codefixes.
+    /// Then gets the string after the codefix is applied and compares it with the expected result.
+    /// Note: If any codefix causes new diagnostics to show up, the test fails unless allowNewCompilerDiagnostics is set to true.
+    /// </summary>
+    /// <param name="language">The language the source code is in</param>
+    /// <param name="analyzer">The analyzer to be applied to the source code</param>
+    /// <param name="codeFixProvider">The codefix to be applied to the code wherever the relevant Diagnostic is found</param>
+    /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
+    /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
+    /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
+    /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+    void VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
+    {
+        var document = CreateDocument(oldSource, language);
+        var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });
+        var compilerDiagnostics = GetCompilerDiagnostics(document);
+        var attempts = analyzerDiagnostics.Length;
 
-            for (int i = 0; i < attempts; ++i)
+        for (var i = 0; i < attempts; ++i)
+        {
+            var actions = new List<CodeAction>();
+            var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, d) => actions.Add(a), CancellationToken.None);
+            codeFixProvider.RegisterCodeFixesAsync(context).Wait();
+
+            if (!actions.Any())
             {
-                var actions = new List<CodeAction>();
-                var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, d) => actions.Add(a), CancellationToken.None);
-                codeFixProvider.RegisterCodeFixesAsync(context).Wait();
-
-                if (!actions.Any())
-                {
-                    break;
-                }
-
-                if (codeFixIndex != null)
-                {
-                    document = ApplyFix(document, actions.ElementAt((int)codeFixIndex));
-                    break;
-                }
-
-                document = ApplyFix(document, actions.ElementAt(0));
-                analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });
-
-                var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
-
-                //check if applying the code fix introduced any new compiler diagnostics
-                if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
-                {
-                    // Format and get the compiler diagnostics again so that the locations make sense in the output
-                    document = document.WithSyntaxRoot(Formatter.Format(document.GetSyntaxRootAsync().Result, Formatter.Annotation, document.Project.Solution.Workspace));
-                    newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
-
-                    Assert.True(false,
-                        string.Format("Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
-                            string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
-                            document.GetSyntaxRootAsync().Result.ToFullString()));
-                }
-
-                //check if there are analyzer diagnostics left after the code fix
-                if (!analyzerDiagnostics.Any())
-                {
-                    break;
-                }
+                break;
             }
 
-            //after applying all of the code fixes, compare the resulting string to the inputted one
-            var actual = GetStringFromDocument(document);
-            Assert.Equal(newSource, actual);
+            if (codeFixIndex != null)
+            {
+                document = ApplyFix(document, actions.ElementAt((int)codeFixIndex));
+                break;
+            }
+
+            document = ApplyFix(document, actions.ElementAt(0));
+            analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });
+
+            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
+
+            //check if applying the code fix introduced any new compiler diagnostics
+            if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
+            {
+                // Format and get the compiler diagnostics again so that the locations make sense in the output
+                document = document.WithSyntaxRoot(Formatter.Format(document.GetSyntaxRootAsync().Result, Formatter.Annotation, document.Project.Solution.Workspace));
+                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
+
+                Assert.True(false,
+                    string.Format("Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
+                        string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
+                        document.GetSyntaxRootAsync().Result.ToFullString()));
+            }
+
+            //check if there are analyzer diagnostics left after the code fix
+            if (!analyzerDiagnostics.Any())
+            {
+                break;
+            }
         }
+
+        //after applying all of the code fixes, compare the resulting string to the inputted one
+        var actual = GetStringFromDocument(document);
+        Assert.Equal(newSource, actual);
     }
 }

--- a/Specifications/CodeAnalysis/Verifiers/DiagnosticVerifier.cs
+++ b/Specifications/CodeAnalysis/Verifiers/DiagnosticVerifier.cs
@@ -1,264 +1,266 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma warning disable SA1629, SA1116, SA1117, CA2000, SA1124, SA1515, SA1202, SA1513, CA1825, SA1005, SA1202, SA1028, SA1202, CA1829, CA1815, SA1204
 
-namespace Aksio.CodeAnalysis
+namespace Aksio.CodeAnalysis;
+
+/// <summary>
+/// Superclass of all Unit Tests for DiagnosticAnalyzers
+/// </summary>
+public abstract partial class DiagnosticVerifier
 {
+    #region To be implemented by Test classes
     /// <summary>
-    /// Superclass of all Unit Tests for DiagnosticAnalyzers
+    /// Get the CSharp analyzer being tested - to be implemented in non-abstract class
     /// </summary>
-    public abstract partial class DiagnosticVerifier
+    protected virtual DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
     {
-        #region To be implemented by Test classes
-        /// <summary>
-        /// Get the CSharp analyzer being tested - to be implemented in non-abstract class
-        /// </summary>
-        protected virtual DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return null;
-        }
-
-        /// <summary>
-        /// Get the Visual Basic analyzer being tested (C#) - to be implemented in non-abstract class
-        /// </summary>
-        protected virtual DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
-        {
-            return null;
-        }
-        #endregion
-
-        #region Verifier wrappers
-
-        /// <summary>
-        /// Called to test a C# DiagnosticAnalyzer when applied on the single inputted string as a source
-        /// Note: input a DiagnosticResult for each Diagnostic expected
-        /// </summary>
-        /// <param name="source">A class in the form of a string to run the analyzer on</param>
-        /// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
-        protected void VerifyCSharpDiagnostic(string source, params DiagnosticResult[] expected)
-        {
-            VerifyDiagnostics(new[] { source }, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), expected);
-        }
-
-        /// <summary>
-        /// Called to test a VB DiagnosticAnalyzer when applied on the single inputted string as a source
-        /// Note: input a DiagnosticResult for each Diagnostic expected
-        /// </summary>
-        /// <param name="source">A class in the form of a string to run the analyzer on</param>
-        /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the source</param>
-        protected void VerifyBasicDiagnostic(string source, params DiagnosticResult[] expected)
-        {
-            VerifyDiagnostics(new[] { source }, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
-        }
-
-        /// <summary>
-        /// Called to test a C# DiagnosticAnalyzer when applied on the inputted strings as a source
-        /// Note: input a DiagnosticResult for each Diagnostic expected
-        /// </summary>
-        /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
-        /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
-        {
-            VerifyDiagnostics(sources, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), expected);
-        }
-
-        /// <summary>
-        /// Called to test a VB DiagnosticAnalyzer when applied on the inputted strings as a source
-        /// Note: input a DiagnosticResult for each Diagnostic expected
-        /// </summary>
-        /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
-        /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        protected void VerifyBasicDiagnostic(string[] sources, params DiagnosticResult[] expected)
-        {
-            VerifyDiagnostics(sources, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
-        }
-
-        /// <summary>
-        /// General method that gets a collection of actual diagnostics found in the source after the analyzer is run, 
-        /// then verifies each of them.
-        /// </summary>
-        /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
-        /// <param name="language">The language of the classes represented by the source strings</param>
-        /// <param name="analyzer">The analyzer to be run on the source code</param>
-        /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        void VerifyDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
-        {
-            var diagnostics = GetSortedDiagnostics(sources, language, analyzer);
-            VerifyDiagnosticResults(diagnostics, analyzer, expected);
-        }
-
-        #endregion
-
-        #region Actual comparisons and verifications
-        /// <summary>
-        /// Checks each of the actual Diagnostics found and compares them with the corresponding DiagnosticResult in the array of expected results.
-        /// Diagnostics are considered equal only if the DiagnosticResultLocation, Id, Severity, and Message of the DiagnosticResult match the actual diagnostic.
-        /// </summary>
-        /// <param name="actualResults">The Diagnostics found by the compiler after running the analyzer on the source code</param>
-        /// <param name="analyzer">The analyzer that was being run on the sources</param>
-        /// <param name="expectedResults">Diagnostic Results that should have appeared in the code</param>
-        static void VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expectedResults)
-        {
-            int expectedCount = expectedResults.Count();
-            int actualCount = actualResults.Count();
-
-            if (expectedCount != actualCount)
-            {
-                string diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzer, actualResults.ToArray()) : "    NONE.";
-
-                Assert.True(false,
-                    string.Format("Mismatch between number of diagnostics returned, expected \"{0}\" actual \"{1}\"\r\n\r\nDiagnostics:\r\n{2}\r\n", expectedCount, actualCount, diagnosticsOutput));
-            }
-
-            for (int i = 0; i < expectedResults.Length; i++)
-            {
-                var actual = actualResults.ElementAt(i);
-                var expected = expectedResults[i];
-
-                if (expected.Line == -1 && expected.Column == -1)
-                {
-                    if (actual.Location != Location.None)
-                    {
-                        Assert.True(false,
-                            string.Format("Expected:\nA project diagnostic with No location\nActual:\n{0}",
-                            FormatDiagnostics(analyzer, actual)));
-                    }
-                }
-                else
-                {
-                    VerifyDiagnosticLocation(analyzer, actual, actual.Location, expected.Locations.First());
-                    var additionalLocations = actual.AdditionalLocations.ToArray();
-
-                    if (additionalLocations.Length != expected.Locations.Length - 1)
-                    {
-                        Assert.True(false,
-                            string.Format("Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
-                                expected.Locations.Length - 1, additionalLocations.Length,
-                                FormatDiagnostics(analyzer, actual)));
-                    }
-
-                    for (int j = 0; j < additionalLocations.Length; ++j)
-                    {
-                        VerifyDiagnosticLocation(analyzer, actual, additionalLocations[j], expected.Locations[j + 1]);
-                    }
-                }
-
-                if (actual.Id != expected.Id)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Id, actual.Id, FormatDiagnostics(analyzer, actual)));
-                }
-
-                if (actual.Severity != expected.Severity)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Severity, actual.Severity, FormatDiagnostics(analyzer, actual)));
-                }
-
-                if (actual.GetMessage() != expected.Message)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Message, actual.GetMessage(), FormatDiagnostics(analyzer, actual)));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Helper method to VerifyDiagnosticResult that checks the location of a diagnostic and compares it with the location in the expected DiagnosticResult.
-        /// </summary>
-        /// <param name="analyzer">The analyzer that was being run on the sources</param>
-        /// <param name="diagnostic">The diagnostic that was found in the code</param>
-        /// <param name="actual">The Location of the Diagnostic found in the code</param>
-        /// <param name="expected">The DiagnosticResultLocation that should have been found</param>
-        static void VerifyDiagnosticLocation(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, Location actual, DiagnosticResultLocation expected)
-        {
-            var actualSpan = actual.GetLineSpan();
-
-            Assert.True(actualSpan.Path == expected.Path || (actualSpan.Path != null && actualSpan.Path.Contains("Test0.") && expected.Path.Contains("Test.")),
-                string.Format("Expected diagnostic to be in file \"{0}\" was actually in file \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                    expected.Path, actualSpan.Path, FormatDiagnostics(analyzer, diagnostic)));
-
-            var actualLinePosition = actualSpan.StartLinePosition;
-
-            // Only check line position if there is an actual line in the real diagnostic
-            if (actualLinePosition.Line > 0)
-            {
-                if (actualLinePosition.Line + 1 != expected.Line)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic to be on line \"{0}\" was actually on line \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Line, actualLinePosition.Line + 1, FormatDiagnostics(analyzer, diagnostic)));
-                }
-            }
-
-            // Only check column position if there is an actual column position in the real diagnostic
-            if (actualLinePosition.Character > 0)
-            {
-                if (actualLinePosition.Character + 1 != expected.Column)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic to start at column \"{0}\" was actually at column \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Column, actualLinePosition.Character + 1, FormatDiagnostics(analyzer, diagnostic)));
-                }
-            }
-        }
-        #endregion
-
-        #region Formatting Diagnostics
-        /// <summary>
-        /// Helper method to format a Diagnostic into an easily readable string
-        /// </summary>
-        /// <param name="analyzer">The analyzer that this verifier tests</param>
-        /// <param name="diagnostics">The Diagnostics to be formatted</param>
-        /// <returns>The Diagnostics formatted as a string</returns>
-        static string FormatDiagnostics(DiagnosticAnalyzer analyzer, params Diagnostic[] diagnostics)
-        {
-            var builder = new StringBuilder();
-            for (int i = 0; i < diagnostics.Length; ++i)
-            {
-                builder.AppendLine("// " + diagnostics[i].ToString());
-
-                var analyzerType = analyzer.GetType();
-                var rules = analyzer.SupportedDiagnostics;
-
-                foreach (var rule in rules)
-                {
-                    if (rule != null && rule.Id == diagnostics[i].Id)
-                    {
-                        var location = diagnostics[i].Location;
-                        if (location == Location.None)
-                        {
-                            builder.AppendFormat("GetGlobalResult({0}.{1})", analyzerType.Name, rule.Id);
-                        }
-                        else
-                        {
-                            Assert.True(location.IsInSource,
-                                $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
-
-                            string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs") ? "GetCSharpResultAt" : "GetBasicResultAt";
-                            var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
-
-                            builder.AppendFormat("{0}({1}, {2}, {3}.{4})",
-                                resultMethodName,
-                                linePosition.Line + 1,
-                                linePosition.Character + 1,
-                                analyzerType.Name,
-                                rule.Id);
-                        }
-
-                        if (i != diagnostics.Length - 1)
-                        {
-                            builder.Append(',');
-                        }
-
-                        builder.AppendLine();
-                        break;
-                    }
-                }
-            }
-            return builder.ToString();
-        }
-        #endregion
+        return null;
     }
+
+    /// <summary>
+    /// Get the Visual Basic analyzer being tested (C#) - to be implemented in non-abstract class
+    /// </summary>
+    protected virtual DiagnosticAnalyzer GetBasicDiagnosticAnalyzer()
+    {
+        return null;
+    }
+    #endregion
+
+    #region Verifier wrappers
+
+    /// <summary>
+    /// Called to test a C# DiagnosticAnalyzer when applied on the single inputted string as a source
+    /// Note: input a DiagnosticResult for each Diagnostic expected
+    /// </summary>
+    /// <param name="source">A class in the form of a string to run the analyzer on</param>
+    /// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
+    protected void VerifyCSharpDiagnostic(string source, params DiagnosticResult[] expected)
+    {
+        VerifyDiagnostics(new[] { source }, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), expected);
+    }
+
+    /// <summary>
+    /// Called to test a VB DiagnosticAnalyzer when applied on the single inputted string as a source
+    /// Note: input a DiagnosticResult for each Diagnostic expected
+    /// </summary>
+    /// <param name="source">A class in the form of a string to run the analyzer on</param>
+    /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the source</param>
+    protected void VerifyBasicDiagnostic(string source, params DiagnosticResult[] expected)
+    {
+        VerifyDiagnostics(new[] { source }, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
+    }
+
+    /// <summary>
+    /// Called to test a C# DiagnosticAnalyzer when applied on the inputted strings as a source
+    /// Note: input a DiagnosticResult for each Diagnostic expected
+    /// </summary>
+    /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
+    /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
+    protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
+    {
+        VerifyDiagnostics(sources, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), expected);
+    }
+
+    /// <summary>
+    /// Called to test a VB DiagnosticAnalyzer when applied on the inputted strings as a source
+    /// Note: input a DiagnosticResult for each Diagnostic expected
+    /// </summary>
+    /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
+    /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
+    protected void VerifyBasicDiagnostic(string[] sources, params DiagnosticResult[] expected)
+    {
+        VerifyDiagnostics(sources, LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), expected);
+    }
+
+    /// <summary>
+    /// General method that gets a collection of actual diagnostics found in the source after the analyzer is run, 
+    /// then verifies each of them.
+    /// </summary>
+    /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
+    /// <param name="language">The language of the classes represented by the source strings</param>
+    /// <param name="analyzer">The analyzer to be run on the source code</param>
+    /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
+    void VerifyDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
+    {
+        var diagnostics = GetSortedDiagnostics(sources, language, analyzer);
+        VerifyDiagnosticResults(diagnostics, analyzer, expected);
+    }
+
+    #endregion
+
+    #region Actual comparisons and verifications
+    /// <summary>
+    /// Checks each of the actual Diagnostics found and compares them with the corresponding DiagnosticResult in the array of expected results.
+    /// Diagnostics are considered equal only if the DiagnosticResultLocation, Id, Severity, and Message of the DiagnosticResult match the actual diagnostic.
+    /// </summary>
+    /// <param name="actualResults">The Diagnostics found by the compiler after running the analyzer on the source code</param>
+    /// <param name="analyzer">The analyzer that was being run on the sources</param>
+    /// <param name="expectedResults">Diagnostic Results that should have appeared in the code</param>
+    static void VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expectedResults)
+    {
+        var expectedCount = expectedResults.Count();
+        var actualCount = actualResults.Count();
+
+        if (expectedCount != actualCount)
+        {
+            var diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzer, actualResults.ToArray()) : "    NONE.";
+
+            Assert.True(false,
+                string.Format("Mismatch between number of diagnostics returned, expected \"{0}\" actual \"{1}\"\r\n\r\nDiagnostics:\r\n{2}\r\n", expectedCount, actualCount, diagnosticsOutput));
+        }
+
+        for (var i = 0; i < expectedResults.Length; i++)
+        {
+            var actual = actualResults.ElementAt(i);
+            var expected = expectedResults[i];
+
+            if (expected.Line == -1 && expected.Column == -1)
+            {
+                if (actual.Location != Location.None)
+                {
+                    Assert.True(false,
+                        string.Format("Expected:\nA project diagnostic with No location\nActual:\n{0}",
+                        FormatDiagnostics(analyzer, actual)));
+                }
+            }
+            else
+            {
+                VerifyDiagnosticLocation(analyzer, actual, actual.Location, expected.Locations.First());
+                var additionalLocations = actual.AdditionalLocations.ToArray();
+
+                if (additionalLocations.Length != expected.Locations.Length - 1)
+                {
+                    Assert.True(false,
+                        string.Format("Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
+                            expected.Locations.Length - 1, additionalLocations.Length,
+                            FormatDiagnostics(analyzer, actual)));
+                }
+
+                for (var j = 0; j < additionalLocations.Length; ++j)
+                {
+                    VerifyDiagnosticLocation(analyzer, actual, additionalLocations[j], expected.Locations[j + 1]);
+                }
+            }
+
+            if (actual.Id != expected.Id)
+            {
+                Assert.True(false,
+                    string.Format("Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                        expected.Id, actual.Id, FormatDiagnostics(analyzer, actual)));
+            }
+
+            if (actual.Severity != expected.Severity)
+            {
+                Assert.True(false,
+                    string.Format("Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                        expected.Severity, actual.Severity, FormatDiagnostics(analyzer, actual)));
+            }
+
+            if (actual.GetMessage() != expected.Message)
+            {
+                Assert.True(false,
+                    string.Format("Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                        expected.Message, actual.GetMessage(), FormatDiagnostics(analyzer, actual)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Helper method to VerifyDiagnosticResult that checks the location of a diagnostic and compares it with the location in the expected DiagnosticResult.
+    /// </summary>
+    /// <param name="analyzer">The analyzer that was being run on the sources</param>
+    /// <param name="diagnostic">The diagnostic that was found in the code</param>
+    /// <param name="actual">The Location of the Diagnostic found in the code</param>
+    /// <param name="expected">The DiagnosticResultLocation that should have been found</param>
+    static void VerifyDiagnosticLocation(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, Location actual, DiagnosticResultLocation expected)
+    {
+        var actualSpan = actual.GetLineSpan();
+
+        Assert.True(actualSpan.Path == expected.Path || (actualSpan.Path != null && actualSpan.Path.Contains("Test0.") && expected.Path.Contains("Test.")),
+            string.Format("Expected diagnostic to be in file \"{0}\" was actually in file \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                expected.Path, actualSpan.Path, FormatDiagnostics(analyzer, diagnostic)));
+
+        var actualLinePosition = actualSpan.StartLinePosition;
+
+        // Only check line position if there is an actual line in the real diagnostic
+        if (actualLinePosition.Line > 0)
+        {
+            if (actualLinePosition.Line + 1 != expected.Line)
+            {
+                Assert.True(false,
+                    string.Format("Expected diagnostic to be on line \"{0}\" was actually on line \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                        expected.Line, actualLinePosition.Line + 1, FormatDiagnostics(analyzer, diagnostic)));
+            }
+        }
+
+        // Only check column position if there is an actual column position in the real diagnostic
+        if (actualLinePosition.Character > 0)
+        {
+            if (actualLinePosition.Character + 1 != expected.Column)
+            {
+                Assert.True(false,
+                    string.Format("Expected diagnostic to start at column \"{0}\" was actually at column \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                        expected.Column, actualLinePosition.Character + 1, FormatDiagnostics(analyzer, diagnostic)));
+            }
+        }
+    }
+    #endregion
+
+    #region Formatting Diagnostics
+    /// <summary>
+    /// Helper method to format a Diagnostic into an easily readable string
+    /// </summary>
+    /// <param name="analyzer">The analyzer that this verifier tests</param>
+    /// <param name="diagnostics">The Diagnostics to be formatted</param>
+    /// <returns>The Diagnostics formatted as a string</returns>
+    static string FormatDiagnostics(DiagnosticAnalyzer analyzer, params Diagnostic[] diagnostics)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < diagnostics.Length; ++i)
+        {
+            builder.AppendLine("// " + diagnostics[i].ToString());
+
+            var analyzerType = analyzer.GetType();
+            var rules = analyzer.SupportedDiagnostics;
+
+            foreach (var rule in rules)
+            {
+                if (rule != null && rule.Id == diagnostics[i].Id)
+                {
+                    var location = diagnostics[i].Location;
+                    if (location == Location.None)
+                    {
+                        builder.AppendFormat("GetGlobalResult({0}.{1})", analyzerType.Name, rule.Id);
+                    }
+                    else
+                    {
+                        Assert.True(location.IsInSource,
+                            $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
+
+                        var resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs") ? "GetCSharpResultAt" : "GetBasicResultAt";
+                        var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
+
+                        builder.AppendFormat("{0}({1}, {2}, {3}.{4})",
+                            resultMethodName,
+                            linePosition.Line + 1,
+                            linePosition.Character + 1,
+                            analyzerType.Name,
+                            rule.Id);
+                    }
+
+                    if (i != diagnostics.Length - 1)
+                    {
+                        builder.Append(',');
+                    }
+
+                    builder.AppendLine();
+                    break;
+                }
+            }
+        }
+        return builder.ToString();
+    }
+    #endregion
 }

--- a/Specifications/GlobalUsings.cs
+++ b/Specifications/GlobalUsings.cs
@@ -1,9 +1,8 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 global using System.Collections.Immutable;
 global using System.Text;
-global using Moq;
-global using static Moq.It;
-global using static Moq.Times;
-global using Xunit;
 global using Microsoft.CodeAnalysis;
 global using Microsoft.CodeAnalysis.CodeActions;
 global using Microsoft.CodeAnalysis.CodeFixes;
@@ -12,3 +11,4 @@ global using Microsoft.CodeAnalysis.Diagnostics;
 global using Microsoft.CodeAnalysis.Formatting;
 global using Microsoft.CodeAnalysis.Simplification;
 global using Microsoft.CodeAnalysis.Text;
+global using Xunit;


### PR DESCRIPTION
### Fixed

- Styled the code according to our style rules.
- Disable requirement for globalization awareness in code, we run our things in controlled environments (#64).
- You have to await calls. Calls that are not awaited (CS4014) will cause a compiler error (#65).
- You have to await within an async method (CS1998) (#65).
