### PR TITLE
Disable CA1305

### DIFF
--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -58,6 +58,7 @@
         <Rule Id="CA1063" Action="None" />
         <Rule Id="CA1065" Action="None" />
         <Rule Id="CA1303" Action="None" />
+        <Rule Id="CA1305" Action="None" />
         <Rule Id="CA1309" Action="None" />
         <Rule Id="CA1308" Action="None" />
         <Rule Id="CA1014" Action="None" />


### PR DESCRIPTION
### Fixed

- Disabling CA1305 related to globalization. We have control over the runtime environment.
