### PR TITLE
Disabling MA0074

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -142,6 +142,7 @@
         <Rule Id="MA0051" Action="None" />
         <Rule Id="MA0054" Action="None" />
         <Rule Id="MA0058" Action="None" />
+        <Rule Id="MA0074" Action="None" />
         <Rule Id="MA0075" Action="None" />
         <Rule Id="MA0076" Action="None" />
     </Rules>

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -119,6 +119,7 @@
         <Rule Id="MA0053" Action="None" />
         <Rule Id="MA0054" Action="None" />
         <Rule Id="MA0058" Action="None" />
+        <Rule Id="MA0074" Action="None" />
         <Rule Id="MA0075" Action="None" />
         <Rule Id="MA0076" Action="None" />
     </Rules>


### PR DESCRIPTION
### Fixed

- Disabling **MA0047** that required one to pass precise `StringComparison` arguments for string comparison methods.
