### PR TITLE
Disabling CA1310

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -80,6 +80,7 @@
         <Rule Id="CA1307" Action="None" />
         <Rule Id="CA1308" Action="None" />
         <Rule Id="CA1309" Action="None" />
+        <Rule Id="CA1310" Action="None" />
         <Rule Id="CA1014" Action="None" />
         <Rule Id="CA1707" Action="None" />
         <Rule Id="CA1710" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -64,6 +64,7 @@
         <Rule Id="CA1305" Action="None" />
         <Rule Id="CA1309" Action="None" />
         <Rule Id="CA1308" Action="None" />
+        <Rule Id="CA1310" Action="None" />
         <Rule Id="CA1014" Action="None" />
         <Rule Id="CA1710" Action="None" />
         <Rule Id="CA1711" Action="None" />


### PR DESCRIPTION
### Fixed

- Disabling CA1310 for not requiring to have to use `StringComparison` for string operations. Our things are primarily backend dockerized solutions, we have control over culture settings.
