### PR TITLE
Disabling CA1307

### DIFF
--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -62,8 +62,9 @@
         <Rule Id="CA1065" Action="None" />
         <Rule Id="CA1303" Action="None" />
         <Rule Id="CA1305" Action="None" />
-        <Rule Id="CA1309" Action="None" />
+        <Rule Id="CA1307" Action="None" />
         <Rule Id="CA1308" Action="None" />
+        <Rule Id="CA1309" Action="None" />
         <Rule Id="CA1310" Action="None" />
         <Rule Id="CA1014" Action="None" />
         <Rule Id="CA1710" Action="None" />


### PR DESCRIPTION
### Fixed

- Disabling CA1307 to avoid having to pass `StringComparison` arguments to string operations like `.Equals()`. Our software runs in controlled environments, we don't need this rule.
