### PR TITLE
Allow using .HasFlag() for bitwize enums

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -114,6 +114,7 @@
         <Rule Id="RCS1019" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
         <Rule Id="RCS1079" Action="None" />
         <Rule Id="RCS1090" Action="None" />
+        <Rule Id="RCS1096" Action="None" />
         <Rule Id="RCS1158" Action="None" />
         <Rule Id="RCS1163" Action="None" />
         <Rule Id="RCS1169" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -94,6 +94,7 @@
         <Rule Id="RCS1057" Action="Error" />
         <Rule Id="RCS1079" Action="None" />
         <Rule Id="RCS1019" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
+        <Rule Id="RCS1096" Action="None" />
         <Rule Id="RCS1158" Action="None" />
         <Rule Id="RCS1163" Action="None" />
         <Rule Id="RCS1182" Action="Error" />


### PR DESCRIPTION
### Fixed

- Disable RCS1096 - we want to encourage the use of `.HasFlag()` as that is more readable than bitwize operators.
