### PR TITLE
Turning off static code analysis for debug configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ and [common project properties](https://docs.microsoft.com/en-us/visualstudio/ms
 It takes advantage of a feature in MSBuild that by convention will include props from a file named the same as its package name in any
 consumers. In our case this is the [Aksio.Defaults.props](./Source/Defaults.Aksio.Defaults.props) and [Aksio.Defaults.Specs.props](./Source/Defaults.Aksio.Defaults.Specs.props).
 
+### Debug vs Release
+
+The default behavior of the static code analysis is to have it disabled while building with the **Debug** Configuration.
+Typically for CI/CD pipelines we run in **Release** and will therefor run all rules there.
+
+If one wants to check things before committing or finalizing a pull request for instance, one could run the build with **Release** configuration
+
+```shell
+$ dotnet build --configuration Release
+```
+
+> Note: It is also possible to run this command as a **Git Hook** either on commit, pre-push or pre-receive for instance, read more [here](https://githooks.com).
+> Since most hooks run on the client and is not configured for the repository, its harder to share in a team. Recommend reading [this](https://www.viget.com/articles/two-ways-to-share-git-hooks-with-your-team/).
+
 ### Static Code Analysis
 
 The props files configures a default behavior for builds with a [common set of static code analysis rules](./Source/Defaults/code_analysis.ruleset) and

--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -12,15 +12,12 @@
     
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)code_analysis.ruleset</CodeAnalysisRuleSet>
 
     <LangVersion>10.0</LangVersion>
 
     <NoWarn>$(NoWarn);NU5105;NU5118;CS1591;CS8632;CS8618;CS0012</NoWarn> <!-- CS0012 - ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
     <Nullable>disable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
-    <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -29,13 +26,17 @@
     <IncludeSymbols>True</IncludeSymbols>
     <IncludeSource>True</IncludeSource>
 
+    <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)code_analysis.ruleset</CodeAnalysisRuleSet>
     <RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>True</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzers>True</RunAnalyzers>
-
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -12,15 +12,12 @@
 
     <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)code_analysis.ruleset</CodeAnalysisRuleSet>
 
     <LangVersion>10.0</LangVersion>
 
     <NoWarn>$(NoWarn);NU5105;NU5118;CS0012</NoWarn> <!-- CS0012 - ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
-    <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -31,13 +28,17 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>    
     <IncludeSource>True</IncludeSource>
 
+    <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)code_analysis.ruleset</CodeAnalysisRuleSet>
     <RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>True</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzers>True</RunAnalyzers>
-
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Changed

- Behavioral change; applying static code analysis rules only on **Release** configuration. This is an experiment to see if we can improve local development productivity without having to disable rules and forgetting re-enable them before pushing.
