### PR TITLE
Setting debug to be default configuration if not set

### DIFF
--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -39,6 +39,10 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'==''">
+    <Configuration>Debug</Configuration>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <RunAnalyzers>False</RunAnalyzers>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>


### PR DESCRIPTION
### Fixed

- Setting **Configuration** to **Debug** as default if not set. Seeing evidence of it not being set at the time the **props** file is implicitly being imported like we do with MSBuild.
