### PR TITLE
Debug should be default for specs as well

### DIFF
--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -37,6 +37,10 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'==''">
+    <Configuration>Debug</Configuration>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <RunAnalyzers>False</RunAnalyzers>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>


### PR DESCRIPTION
### Fixed

- Setting default **Debug** **configuration** for Specs as well as regular projects.
