### PR TITLE
Disabling IDE0042 - requiring deconstruction of tuples

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -46,6 +46,7 @@
         <Rule Id="IDE0010" Action="None" />
         <Rule Id="IDE0040" Action="None" />
         <Rule Id="IDE0040WithoutSuggestion" Action="None" />
+        <Rule Id="IDE0042" Action="None" />
         <Rule Id="IDE0044" Action="None" />
         <Rule Id="IDE0060" Action="None" />
         <Rule Id="IDE0051" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -37,6 +37,7 @@
         <Rule Id="IDE0010" Action="None" />
         <Rule Id="IDE0040" Action="None" />
         <Rule Id="IDE0040WithoutSuggestion" Action="None" />        
+        <Rule Id="IDE0042" Action="None" />
         <Rule Id="IDE0055" Action="None" />
         <Rule Id="IDE0072" Action="None" />
         <Rule Id="IDE0083" Action="None" />


### PR DESCRIPTION
### Fixed

- Disabling IDE0042 that requires deconstruction of tuples returned.
