### PR TITLE
Adding properties to get PDB files and source included in packages

### DIFF
--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -24,9 +24,15 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsTestProject>false</IsTestProject>
 
+    <!-- Debuggability -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>    
     <IncludeSource>True</IncludeSource>
+    <EmbedAllSources>True</EmbedAllSources>
+    <DebugType>Embedded</DebugType>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <!-- Debuggability - End -->
 
     <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>


### PR DESCRIPTION
### Added

- Adding properties for NuGet to include both source and the PDB files when packaging. Increases debugability across different environments. Downside is larger packages.
