### PR TITLE
Reverting back to not include PDB files

### DIFF
--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -25,6 +25,7 @@
     <IsTestProject>false</IsTestProject>
 
     <!-- Debuggability -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>    
     <IncludeSource>True</IncludeSource>

--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -25,13 +25,9 @@
     <IsTestProject>false</IsTestProject>
 
     <!-- Debuggability -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>    
     <IncludeSource>True</IncludeSource>
-    <EmbedAllSources>True</EmbedAllSources>
-    <DebugType>Embedded</DebugType>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <!-- Debuggability - End -->
 
     <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>


### PR DESCRIPTION
### Fixed

- Reverting; excluding PDB files from packages. Relying on Source Link instead. PS: must be added in the project that published for the correct source control provider. Read more [here](https://github.com/dotnet/sourcelink#githubcom-and-github-enterprise).
