### PR TITLE
Removing RepositoryUrl - this has to be owned be the respective projects

### DIFF
--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -7,7 +7,6 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/aksio-system/Home</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>


### PR DESCRIPTION
### Fixed

- Removing default `<RepositoryUrl/>`. Apparently this ends up as `<repoitory url=""/>` even when overridden in a project.
