### PR TITLE
Setting errors to warnings and treat warnings as errors only on release build

### DIFF
--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -17,8 +17,8 @@
 
     <NoWarn>$(NoWarn);NU5105;NU5118;CS1591;CS8632;CS8618;CS0012</NoWarn> <!-- CS0012 - ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
     <Nullable>disable</Nullable>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' ">true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' ">true</MSBuildTreatWarningsAsErrors>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IsTestProject>false</IsTestProject>
@@ -29,7 +29,6 @@
     <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
-    <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)code_analysis.ruleset</CodeAnalysisRuleSet>
     <RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>True</RunAnalyzersDuringLiveAnalysis>
@@ -42,9 +41,17 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <RunAnalyzers>False</RunAnalyzers>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <MSBuildTreatWarningsAsErrors>False</MSBuildTreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>False</CodeAnalysisTreatWarningsAsErrors>
+    <StyleCopTreatErrorsAsWarnings>False</StyleCopTreatErrorsAsWarnings>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>True</MSBuildTreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
+    <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -7,8 +7,8 @@
    
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
         <Rule Id="CS0103" Action="None" />
-        <Rule Id="CS1998" Action="Error" />
-        <Rule Id="CS4014" Action="Error" />
+        <Rule Id="CS1998" Action="Warning" />
+        <Rule Id="CS4014" Action="Warning" />
         <Rule Id="SA0001" Action="None" />
         <Rule Id="SA1009" Action="None" />
         <Rule Id="SA1012" Action="None" />

--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -16,8 +16,6 @@
 
     <NoWarn>$(NoWarn);NU5105;NU5118;CS0012</NoWarn> <!-- CS0012 - ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
     <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -30,10 +28,8 @@
     <IncludeSource>True</IncludeSource>
     <!-- Debuggability - End -->
 
-    <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-
-    <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
+    
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)code_analysis.ruleset</CodeAnalysisRuleSet>
     <RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>True</RunAnalyzersDuringLiveAnalysis>
@@ -46,9 +42,17 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <RunAnalyzers>False</RunAnalyzers>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <MSBuildTreatWarningsAsErrors>False</MSBuildTreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>False</CodeAnalysisTreatWarningsAsErrors>
+    <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>True</MSBuildTreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
+    <StyleCopTreatErrorsAsWarnings>False</StyleCopTreatErrorsAsWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -7,21 +7,21 @@
 
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
         <Rule Id="CS0103" Action="None" />
-        <Rule Id="CS1998" Action="Error" />
-        <Rule Id="CS4014" Action="Error" />
+        <Rule Id="CS1998" Action="Warning" />
+        <Rule Id="CS4014" Action="Warning" />
         <Rule Id="SA1000" Action="None" />
         <Rule Id="SA1009" Action="None" />
         <Rule Id="SA1101" Action="None" />
         <Rule Id="SA1115" Action="None" />
         <Rule Id="SA1128" Action="None" />
-        <Rule Id="SA1200" Action="Error" />
+        <Rule Id="SA1200" Action="Warning" />
         <Rule Id="SA1201" Action="None" />
-        <Rule Id="SA1210" Action="Error" />
+        <Rule Id="SA1210" Action="Warning" />
         <Rule Id="SA1300" Action="None" />
         <Rule Id="SA1309" Action="None" />
         <Rule Id="SA1400" Action="None" />
         <Rule Id="SA1401" Action="None" />
-        <Rule Id="SA1402" Action="Error" />
+        <Rule Id="SA1402" Action="Warning" />
         <Rule Id="SA1413" Action="None" />
         <Rule Id="SA1501" Action="None" />
         <Rule Id="SA1503" Action="None" />
@@ -32,8 +32,8 @@
         <Rule Id="SA1642" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
-        <Rule Id="IDE0003" Action="Error" />
-        <Rule Id="IDE0005" Action="Error" />
+        <Rule Id="IDE0003" Action="Warning" />
+        <Rule Id="IDE0005" Action="Warning" />
         <Rule Id="IDE0010" Action="None" />
         <Rule Id="IDE0040" Action="None" />
         <Rule Id="IDE0040WithoutSuggestion" Action="None" />        
@@ -43,7 +43,7 @@
         <Rule Id="IDE0083" Action="None" />
         <Rule Id="IDE0130" Action="None" />
         <Rule Id="IDE0160" Action="None" />
-        <Rule Id="IDE1006" Action="Error" />
+        <Rule Id="IDE1006" Action="Warning" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.EditorFeatures" RuleNamespace="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
     </Rules>  
@@ -79,13 +79,13 @@
         <Rule Id="CA1812" Action="None" />
         <Rule Id="CA1816" Action="None" />
         <Rule Id="CA1822" Action="None" />
-        <Rule Id="CA1829" Action="Error" />
+        <Rule Id="CA1829" Action="Warning" />
         <Rule Id="CA1834" Action="None" />
-        <Rule Id="CA2000" Action="Error" /> <!-- To avoid memory leakage of unmanaged memory. Make sure disposable objects are disposed. -->
+        <Rule Id="CA2000" Action="Warning" /> <!-- To avoid memory leakage of unmanaged memory. Make sure disposable objects are disposed. -->
         <Rule Id="CA2007" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
         <Rule Id="CA2016" Action="None" />
         <Rule Id="CA2211" Action="None" />
-        <Rule Id="CA2213" Action="Error" /> <!-- To avoid memory leakage of unmanaged memory. Make sure fields holding disposables are disposed. -->
+        <Rule Id="CA2213" Action="Warning" /> <!-- To avoid memory leakage of unmanaged memory. Make sure fields holding disposables are disposed. -->
         <Rule Id="CA2225" Action="None" />
         <Rule Id="CA2227" Action="None" />
         <Rule Id="CA2234" Action="None" />
@@ -94,13 +94,13 @@
     </Rules>
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
         <Rule Id="RCS1018" Action="None" />
-        <Rule Id="RCS1057" Action="Error" />
+        <Rule Id="RCS1057" Action="Warning" />
         <Rule Id="RCS1079" Action="None" />
         <Rule Id="RCS1019" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
         <Rule Id="RCS1096" Action="None" />
         <Rule Id="RCS1158" Action="None" />
         <Rule Id="RCS1163" Action="None" />
-        <Rule Id="RCS1182" Action="Error" />
+        <Rule Id="RCS1182" Action="Warning" />
         <Rule Id="RCS1194" Action="None" />
         <Rule Id="RCS1217" Action="None" />
         <Rule Id="RCS1225" Action="None" />


### PR DESCRIPTION
### Fixed

- Making explicit configured errors be warning and only treat warnings as errors during release build. Related to #78.
